### PR TITLE
fix: Ensure visibility of dynamic backgrounds

### DIFF
--- a/src/components/layout/RadioPageLayout.tsx
+++ b/src/components/layout/RadioPageLayout.tsx
@@ -42,7 +42,10 @@ const RadioPageLayout: React.FC<RadioPageLayoutProps> = ({
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-orange-900 via-red-900 to-purple-900 relative overflow-hidden">
+      {/* Background Element is rendered first */}
       {backgroundElement}
+      {/* Global Overlay, rendered on top of backgroundElement */}
+      <div className="absolute inset-0 bg-black/30 backdrop-blur-[1px] z-0"></div>
 
       <ReactPlayer
         ref={playerRef}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -125,11 +125,10 @@ const Index = () => {
     <RadioPageLayout
       backgroundElement={
         <div
-          className="absolute inset-0 bg-cover bg-center bg-no-repeat"
+          className="absolute inset-0 w-full h-full bg-cover bg-center bg-no-repeat" // Ensured w-full h-full
           style={{ backgroundImage: `url('${currentBackgroundImage}')` }}
-        >
-          <div className="absolute inset-0 bg-black/30 backdrop-blur-[1px]" />
-        </div>
+          // The inner overlay div has been removed.
+        />
       }
       currentProgramForPlayer={currentProgram}
       headerActions={headerActionButtons}

--- a/src/pages/ProgramSponsorSlideshowPage.tsx
+++ b/src/pages/ProgramSponsorSlideshowPage.tsx
@@ -119,7 +119,7 @@ const ProgramSponsorSlideshowPage = () => {
         height: '100%',
         top: 0,
         left: 0,
-        zIndex: -1, // Behind the layout's overlay
+        // zIndex: -1, // Removed: z-index is handled by RadioPageLayout's overlay
       }}
     >
       <img
@@ -134,7 +134,7 @@ const ProgramSponsorSlideshowPage = () => {
           opacity: isFading ? 0 : 1,
         }}
       />
-      <div className="absolute inset-0 bg-black/30 backdrop-blur-[1px]"></div> {/* The overlay from original Index.tsx BG */}
+      {/* Inner overlay div removed, global overlay is in RadioPageLayout */}
     </div>
   );
 

--- a/src/pages/SponsorVideoPage.tsx
+++ b/src/pages/SponsorVideoPage.tsx
@@ -95,7 +95,7 @@ const SponsorVideoPage = () => {
         objectFit: 'cover',
         top: 0,
         left: 0,
-        zIndex: -1, // Behind the layout's overlay
+        // zIndex: -1, // Removed: z-index is handled by RadioPageLayout's overlay
       }}
       src={videoBackgroundUrl}
     >


### PR DESCRIPTION
This commit addresses an issue where video and image slideshow backgrounds were not visible on their respective pages.

The fix involves:
- Refactoring `RadioPageLayout.tsx` to manage a global background overlay. The layout now renders the page-specific `backgroundElement` and then applies a consistent semi-transparent overlay on top.
- Updating `Index.tsx`, `SponsorVideoPage.tsx`, and `ProgramSponsorSlideshowPage.tsx` to:
    - Remove their individual overlay implementations from their `backgroundElement`.
    - Remove `zIndex: -1` from their background elements to prevent them from being hidden behind the main layout's gradient background.
    - Ensure their background elements are styled correctly to fill the viewport under the global overlay.

This ensures that all background types (static image, video, image slideshow) are correctly displayed full-page beneath the site content.