### PR TITLE
fix: Correct syntax error in PlaylistPage track mapping

### DIFF
--- a/src/pages/PlaylistPage.tsx
+++ b/src/pages/PlaylistPage.tsx
@@ -107,7 +107,6 @@ const PlaylistPage = () => {
             {selectedPlaylist ? (
               <ScrollArea className="h-[calc(100vh-300px)]"> {/* Adjust height as needed */}
                 <div className="space-y-3 pr-4">
-                  {selectedPlaylist.tracks.map((track) => (
                   {selectedPlaylist.tracks.map((track, index) => (
                     <div key={track.id} className="flex items-center space-x-3 p-2 bg-white/5 rounded-lg hover:bg-white/10 transition-colors">
                       {track.imageUrl ? (


### PR DESCRIPTION
Removes a duplicated line in the `.map()` call used for rendering tracks in `src/pages/PlaylistPage.tsx`. This resolves a syntax error that prevented the page from rendering correctly.

This commit also includes the previously developed features for the Playlist Page and slideshow enhancements.