### PR TITLE
fix: Correct import of mock data for PlaylistPage

### DIFF
--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -24,7 +24,7 @@ export interface Advertisement {
 }
 
 // Mock Data
-const mockPrograms: Program[] = [
+export const mockPrograms: Program[] = [
   {
     id: "program1",
     name: "Morning Vibes",
@@ -48,7 +48,7 @@ const mockPrograms: Program[] = [
   },
 ];
 
-const mockAdvertisements: Advertisement[] = [
+export const mockAdvertisements: Advertisement[] = [
   {
     id: "ad1",
     name: "Awesome Product",


### PR DESCRIPTION
Exports `mockPrograms` and `mockAdvertisements` from `Index.tsx` so they can be correctly imported into `PlaylistPage.tsx`. This resolves a runtime error caused by missing exports.

This commit also includes the previously developed features:
- Playlist Page with playback capabilities.
- Enhancements to slideshow timings and transitions.
- Correction of a minor syntax error in PlaylistPage.tsx.