### PR TITLE
style: Refine slideshow transition timings

### DIFF
--- a/src/pages/ProgramSponsorSlideshowPage.tsx
+++ b/src/pages/ProgramSponsorSlideshowPage.tsx
@@ -99,8 +99,8 @@ const ProgramSponsorSlideshowPage = () => {
           prevImage === programImageUrl ? sponsorImageUrl : programImageUrl
         );
         setIsFading(false);
-      }, 2000); // Updated to 2s for fade-out, matches CSS transition
-    }, 8000); // Updated to 8 seconds total cycle time (2s fade + 6s visible)
+      }, 3000); // Changed to 3s for fade-out
+    }, 10000); // Changed to 10 seconds total cycle time (3s fade + 4s visible + 3s fade)
 
     return () => clearInterval(intervalId); // Cleanup interval on unmount
   }, [programImageUrl, sponsorImageUrl]);
@@ -130,7 +130,7 @@ const ProgramSponsorSlideshowPage = () => {
           width: '100%',
           height: '100%',
           objectFit: 'cover',
-          transition: 'opacity 2s ease-in-out', // Updated transition duration
+          transition: 'opacity 3s ease-in-out', // Changed transition duration
           opacity: isFading ? 0 : 1,
         }}
       />


### PR DESCRIPTION
Updates the slideshow transition timings in ProgramSponsorSlideshowPage.tsx to create a smoother and more immersive effect as per your feedback.

- CSS opacity transition duration increased from 2s to 3s.
- JavaScript setTimeout for fade state change increased to 3s.
- JavaScript setInterval for slide cycle increased to 10s.

This results in a 3-second fade-in/out and 4 seconds of fully visible time per slide.