### PR TITLE
fix: Improve slideshow fade-in transition reliability

### DIFF
--- a/src/pages/ProgramSponsorSlideshowPage.tsx
+++ b/src/pages/ProgramSponsorSlideshowPage.tsx
@@ -98,7 +98,16 @@ const ProgramSponsorSlideshowPage = () => {
         setCurrentSlideImage(prevImage =>
           prevImage === programImageUrl ? sponsorImageUrl : programImageUrl
         );
-        setIsFading(false);
+        // isFading is still true here. The new image identified by 'key'
+        // will attempt to render with opacity: 0.
+
+        // Use requestAnimationFrame to delay setting isFading to false,
+        // ensuring the opacity transition for fade-in occurs.
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => { // Double rAF for robustness against browser rendering quirks
+            setIsFading(false);
+          });
+        });
       }, 3000); // Changed to 3s for fade-out
     }, 10000); // Changed to 10 seconds total cycle time (3s fade + 4s visible + 3s fade)
 


### PR DESCRIPTION
Modifies the slideshow logic in ProgramSponsorSlideshowPage.tsx to ensure a more distinct and smoother fade-in effect for new slides.

Uses a nested `requestAnimationFrame` within the `setTimeout` callback after changing the image source. This allows the browser to process the new image with `opacity: 0` before the `isFading = false` state change triggers the fade-in transition, making the effect more reliable.