### PR TITLE
Fix: Remove potentially problematic semicolon in MobileNavbar.tsx

### DIFF
--- a/src/components/mobile/MobileNavbar.tsx
+++ b/src/components/mobile/MobileNavbar.tsx
@@ -42,6 +42,6 @@ const MobileNavbar = ({
             </div>
           </div>}
       </div>
-    </div>;
+    </div>
 };
 export default MobileNavbar;


### PR DESCRIPTION
Removed a semicolon from the end of a `</div>` tag in `src/components/mobile/MobileNavbar.tsx`.

This semicolon was not standard JSX practice and could have been misinterpreted by the JavaScript/TypeScript parser, potentially leading to an "Unterminated regular expression" error if the parser was in an ambiguous state.