### PR TITLE
Style: Update MobileNavbar text color and logo visibility

### DIFF
--- a/src/components/mobile/MobileNavbar.tsx
+++ b/src/components/mobile/MobileNavbar.tsx
@@ -20,11 +20,11 @@ const MobileNavbar = ({
         {/* Main navbar */}
         <div className="flex items-center justify-between p-2">
           <div className="w-12 h-12 bg-white rounded-lg flex items-center justify-center">
-              <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR6RFZ_DjLPAbpKy6YRptoo6QFCSVF3PFLNLQ&s" alt="Amblé Radio" className="w-10 h-8 object-contain" />
+              <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR6RFZ_DjLPAbpKy6YRptoo6QFCSVF3PFLNLQ&s" alt="Amblé Radio" className="w-full h-full object-contain" />
             </div>
               <div>
-              <h1 className="text-white font-bold text-xl">Amblé Radio</h1>
-              <p className="text-white/70 text-sm">Fresh Sound & Podcasts</p>
+              <h1 className="text-black font-bold text-xl">Amblé Radio</h1>
+              <p className="text-black text-sm">Fresh Sound & Podcasts</p>
             </div>
           </div>
           


### PR DESCRIPTION
- Changed "Amblé Radio" and "Fresh Sound & Podcasts" text to black.
- Adjusted logo image to be fully visible within its container by using w-full h-full with object-contain. This addresses an issue where the logo was previously cropped.