### PR TITLE
feat: Add logo and brand text to mobile navbar

### DIFF
--- a/src/components/mobile/MobileNavbar.tsx
+++ b/src/components/mobile/MobileNavbar.tsx
@@ -16,18 +16,19 @@ const MobileNavbar = ({
   };
   const menuItems = ["Live", "Podcast", "Palinsesto", "Chi siamo", "Contatti"];
   return <div className="fixed top-[5px] left-1/2 transform -translate-x-1/2 w-[90%] z-30 md:hidden">
-      <div className={`bg-white shadow-lg transition-all duration-300 ease-in-out ${isMenuOpen ? "rounded-t-lg rounded-b-lg" : "rounded-lg"}`}>
+      <div className={`bg-transparent shadow-lg transition-all duration-300 ease-in-out ${isMenuOpen ? "rounded-t-lg rounded-b-lg" : "rounded-lg"}`}>
         {/* Main navbar */}
         <div className="flex items-center justify-between p-2">
-          <div className="w-8 h-8">
-            <img src="/public/lovable-uploads/298d2b4c-882d-4699-ae78-2ef0a6515c91.png" alt="Amblé Radio" className="w-full h-full object-cover" />
+          <div className="w-12 h-12 bg-white rounded-lg flex items-center justify-center">
+            <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR6RFZ_DjLPAbpKy6YRptoo6QFCSVF3PFLNLQ&s" alt="Amblé Radio" className="w-10 h-8 object-contain" />
           </div>
           
           <div className="flex-1 text-center px-2">
-            <span className="font-semibold text-gray-800 leading-tight text-xs"></span>
+            <span className="text-white font-bold text-base">Amblé Radio</span>
+            <p className="text-white/70 text-xs">Fresh Sound & Podcasts</p>
           </div>
           
-          <Button onClick={toggleMenu} variant="ghost" size="sm" className="text-gray-800 font-medium py-1 bg-transparent px-[12px] text-base">
+          <Button onClick={toggleMenu} variant="ghost" size="sm" className="text-white font-medium py-1 bg-transparent px-[12px] text-base">
             {isMenuOpen ? "- CLOSE" : "+ MENU"}
           </Button>
         </div>


### PR DESCRIPTION
Updates the mobile navigation bar (`MobileNavbar.tsx`) to include the company logo and brand name/tagline, mirroring the desktop header's presentation.

Key changes:
- Sets the mobile logo image to the same source as the desktop version.
- Styles the mobile logo container with a white background for visibility and consistency.
- Adds "Amblé Radio" and "Fresh Sound & Podcasts" text to the mobile navbar.
- Changes the text color for these new elements and the existing "+ MENU" button to white.
- Modifies the mobile navbar's main background to be transparent, ensuring the white text is legible against the typically darker page backgrounds.

These changes address the issue of the mobile header lacking the brand identity present in the desktop view and ensure the "+ MENU" text is styled as requested.