### PR TITLE
refactor: Adjust mobile navbar layout and remove player SVG

### DIFF
--- a/src/components/layout/RadioPageLayout.tsx
+++ b/src/components/layout/RadioPageLayout.tsx
@@ -126,9 +126,6 @@ const RadioPageLayout: React.FC<RadioPageLayoutProps> = ({
       <div className="fixed bottom-0 left-0 right-0 bg-black/80 backdrop-blur-xl border-t border-white/10 p-4 z-20">
         <div className="flex items-center justify-between max-w-7xl mx-auto">
           <div className="flex items-center space-x-4">
-            <div className="w-12 h-12 bg-gradient-to-br from-pink-500 to-orange-500 rounded-lg flex items-center justify-center">
-              <Radio className="w-6 h-6 text-white" />
-            </div>
             <div>
               <p className="text-white font-medium truncate w-48" title={currentTrackTitle}>{currentTrackTitle}</p>
               <p className="text-white/60 text-sm truncate w-48" title={currentTrackArtist}>{currentTrackArtist}</p>

--- a/src/components/mobile/MobileNavbar.tsx
+++ b/src/components/mobile/MobileNavbar.tsx
@@ -19,13 +19,14 @@ const MobileNavbar = ({
       <div className={`bg-transparent shadow-lg transition-all duration-300 ease-in-out ${isMenuOpen ? "rounded-t-lg rounded-b-lg" : "rounded-lg"}`}>
         {/* Main navbar */}
         <div className="flex items-center justify-between p-2">
-          <div className="w-12 h-12 bg-white rounded-lg flex items-center justify-center">
-            <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR6RFZ_DjLPAbpKy6YRptoo6QFCSVF3PFLNLQ&s" alt="Amblé Radio" className="w-10 h-8 object-contain" />
-          </div>
-          
-          <div className="flex-1 text-center px-2">
-            <span className="text-white font-bold text-base">Amblé Radio</span>
-            <p className="text-white/70 text-xs">Fresh Sound & Podcasts</p>
+          <div className="flex items-center space-x-2"> {/* New wrapper div */}
+            <div className="w-12 h-12 bg-white rounded-lg flex items-center justify-center">
+              <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR6RFZ_DjLPAbpKy6YRptoo6QFCSVF3PFLNLQ&s" alt="Amblé Radio" className="w-10 h-8 object-contain" />
+            </div>
+            <div className="text-left"> {/* Modified text div */}
+              <span className="text-white font-bold text-base">Amblé Radio</span>
+              <p className="text-white/70 text-xs">Fresh Sound & Podcasts</p>
+            </div>
           </div>
           
           <Button onClick={toggleMenu} variant="ghost" size="sm" className="text-white font-medium py-1 bg-transparent px-[12px] text-base">


### PR DESCRIPTION
Further refines the mobile experience based on your feedback:

- Modifies `MobileNavbar.tsx` to position the brand name and tagline directly next to the logo, improving visual grouping and alignment. The text is now left-aligned within this group.
- Removes a decorative SVG icon (Radio icon) and its container `div` from the bottom player in `RadioPageLayout.tsx` as you requested.

These changes address specific layout requests for the mobile header and the audio player.