### PR TITLE
feat: Revamp mobile menu display and animations

### DIFF
--- a/src/components/mobile/MobileNavbar.tsx
+++ b/src/components/mobile/MobileNavbar.tsx
@@ -15,8 +15,8 @@ const MobileNavbar = ({
     setIsMenuOpen(false);
   };
   const menuItems = ["Live", "Podcast", "Palinsesto", "Chi siamo", "Contatti"];
-  return <div className="fixed top-[5px] left-1/2 transform -translate-x-1/2 w-[90%] z-30 md:hidden">
-      <div className={`bg-transparent shadow-lg transition-all duration-300 ease-in-out ${isMenuOpen ? "rounded-t-lg rounded-b-lg" : "rounded-lg"}`}>
+  return <div className={isMenuOpen ? "md:hidden fixed inset-0 z-50 bg-white flex flex-col" : "md:hidden fixed top-[5px] left-1/2 transform -translate-x-1/2 w-[90%] z-30"}>
+      <div className={isMenuOpen ? "flex flex-col h-full" : "bg-transparent shadow-lg rounded-lg"}>
         {/* Main navbar */}
         <div className="flex items-center justify-between p-2">
           <div className="flex items-center space-x-2"> {/* New wrapper div */}
@@ -35,9 +35,9 @@ const MobileNavbar = ({
         </div>
 
         {/* Expandable menu */}
-        {isMenuOpen && <div className="border-t border-gray-200 bg-white rounded-b-lg">
+        {isMenuOpen && <div className="border-t border-gray-200 flex-grow overflow-y-auto">
             <div className="py-2">
-              {menuItems.map((item, index) => <button key={index} onClick={() => handleMenuItemClick(item)} className="w-full text-left px-4 py-3 text-gray-800 hover:bg-gray-50 transition-colors text-sm font-medium">
+              {menuItems.map((item, index) => <button key={index} onClick={() => handleMenuItemClick(item)} style={{ transitionDelay: isMenuOpen ? `${index * 75}ms` : '0ms' }} className={`w-full text-left px-4 py-4 text-gray-800 hover:bg-gray-50 text-sm font-medium border-b border-gray-200 last:border-b-0 transition-all duration-300 ease-out ${isMenuOpen ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
                   {item}
                 </button>)}
             </div>


### PR DESCRIPTION
This commit implements a significant redesign of the mobile navigation menu:

1.  **Full-Page Menu:** The menu now expands to a full-page view when activated, providing a more immersive experience. The background is set to white.

2.  **Link Styling:**
    *   Menu links are now full-width and left-aligned.
    *   Each link features a 1px bottom border (#eeeeee, implemented as border-gray-200). The last item omits this border.
    *   Padding and font settings have been adjusted to ensure the text effectively utilizes the available line height within each item.

3.  **Stagger Animation:**
    *   Menu items now appear with a stagger animation when the menu is opened.
    *   Items fade in and slide up, with each subsequent item slightly delayed, creating a smooth, cascading effect.

These changes enhance your experience on mobile devices by providing a clearer, more modern, and engaging navigation system.