### PR TITLE
refactor: Refine mobile menu styling and animations

### DIFF
--- a/src/components/mobile/MobileNavbar.tsx
+++ b/src/components/mobile/MobileNavbar.tsx
@@ -16,20 +16,20 @@ const MobileNavbar = ({
   };
   const menuItems = ["Live", "Podcast", "Palinsesto", "Chi siamo", "Contatti"];
   return <div className={isMenuOpen ? "md:hidden fixed inset-0 z-50 bg-white flex flex-col" : "md:hidden fixed top-[5px] left-1/2 transform -translate-x-1/2 w-[90%] z-30"}>
-      <div className={isMenuOpen ? "flex flex-col h-full" : "bg-transparent shadow-lg rounded-lg"}>
+      <div className={isMenuOpen ? 'flex flex-col h-full translate-y-0 transition-transform duration-300 ease-in-out' : 'bg-transparent shadow-lg rounded-lg -translate-y-full transition-transform duration-300 ease-in-out'}>
         {/* Main navbar */}
-        <div className="flex items-center justify-between p-2">
-          <div className="flex items-center space-x-2"> {/* New wrapper div */}
+        <div className={`flex items-center p-2 ${isMenuOpen ? '' : 'justify-between'}`}>
+          <div className={`flex items-center space-x-2 ${isMenuOpen ? 'flex-1' : ''}`}> {/* New wrapper div */}
             <div className="w-12 h-12 bg-white rounded-lg flex items-center justify-center">
               <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR6RFZ_DjLPAbpKy6YRptoo6QFCSVF3PFLNLQ&s" alt="Amblé Radio" className="w-10 h-8 object-contain" />
             </div>
-            <div className="text-left"> {/* Modified text div */}
-              <span className="text-white font-bold text-base">Amblé Radio</span>
-              <p className="text-white/70 text-xs">Fresh Sound & Podcasts</p>
+            <div className={`${isMenuOpen ? 'text-center flex-1' : 'text-left'}`}> {/* Modified text div */}
+              <span className={isMenuOpen ? 'text-black font-bold text-base' : 'text-white font-bold text-base'}>Amblé Radio</span>
+              <p className={isMenuOpen ? 'text-black text-xs' : 'text-white/70 text-xs'}>Fresh Sound & Podcasts</p>
             </div>
           </div>
           
-          <Button onClick={toggleMenu} variant="ghost" size="sm" className="text-white font-medium py-1 bg-transparent px-[12px] text-base">
+          <Button onClick={toggleMenu} variant="ghost" size="sm" className={`font-medium py-1 bg-transparent px-[12px] text-base ${isMenuOpen ? 'text-black' : 'text-white'}`}>
             {isMenuOpen ? "- CLOSE" : "+ MENU"}
           </Button>
         </div>
@@ -37,7 +37,7 @@ const MobileNavbar = ({
         {/* Expandable menu */}
         {isMenuOpen && <div className="border-t border-gray-200 flex-grow overflow-y-auto">
             <div className="py-2">
-              {menuItems.map((item, index) => <button key={index} onClick={() => handleMenuItemClick(item)} style={{ transitionDelay: isMenuOpen ? `${index * 75}ms` : '0ms' }} className={`w-full text-left px-4 py-4 text-gray-800 hover:bg-gray-50 text-sm font-medium border-b border-gray-200 last:border-b-0 transition-all duration-300 ease-out ${isMenuOpen ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+              {menuItems.map((item, index) => <button key={index} onClick={() => handleMenuItemClick(item)} style={{ transitionDelay: isMenuOpen ? `${index * 75}ms` : '0ms' }} className={`w-full text-left px-4 py-4 text-gray-800 hover:bg-gray-50 text-base font-medium uppercase border-b border-dotted border-gray-200 last:border-b-0 transition-all duration-300 ease-out ${isMenuOpen ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
                   {item}
                 </button>)}
             </div>


### PR DESCRIPTION
This commit applies your requested refinements to the mobile menu:

1.  **Link Styling Adjustments:**
    *   Menu item links now use a `border-dotted` bottom border.
    *   Font size for links increased to `text-base`.
    *   Link text is now displayed in `uppercase`.

2.  **Claim Text Enhancements (Open Menu):**
    *   The "Amblé Radio Fresh Sound & Podcasts" claim text and the menu toggle button text now change to black for better visibility on the white background when the menu is open.
    *   The claim text is now horizontally centered within the header, positioned between the logo and the menu toggle button, when the menu is active.

3.  **Menu Animation Update:**
    *   The opening/closing animation for the full-page menu has been updated. The entire menu content now slides in from the top (`-translate-y-full` to `translate-y-0`) with a `duration-300ms ease-in-out` transition, providing a softer and more fluid effect.
    *   Individual menu item stagger animations are preserved and occur within the main sliding container.

These changes further improve the mobile menu's aesthetics and user experience based on your feedback.