### PR TITLE
fix: Restore visibility of collapsed mobile navbar

### DIFF
--- a/src/components/mobile/MobileNavbar.tsx
+++ b/src/components/mobile/MobileNavbar.tsx
@@ -16,7 +16,7 @@ const MobileNavbar = ({
   };
   const menuItems = ["Live", "Podcast", "Palinsesto", "Chi siamo", "Contatti"];
   return <div className={isMenuOpen ? "md:hidden fixed inset-0 z-50 bg-white flex flex-col" : "md:hidden fixed top-[5px] left-1/2 transform -translate-x-1/2 w-[90%] z-30"}>
-      <div className={isMenuOpen ? 'flex flex-col h-full translate-y-0 transition-transform duration-300 ease-in-out' : 'bg-transparent shadow-lg rounded-lg -translate-y-full transition-transform duration-300 ease-in-out'}>
+      <div className={isMenuOpen ? 'flex flex-col h-full translate-y-0 transition-transform duration-300 ease-in-out' : 'bg-transparent shadow-lg rounded-lg'}>
         {/* Main navbar */}
         <div className={`flex items-center p-2 ${isMenuOpen ? '' : 'justify-between'}`}>
           <div className={`flex items-center space-x-2 ${isMenuOpen ? 'flex-1' : ''}`}> {/* New wrapper div */}


### PR DESCRIPTION
This commit addresses an issue where the collapsed mobile navbar (preview bar) was inadvertently hidden after recent animation changes.

The `InnerDiv` component, which provides the visual styling for the collapsed bar, was being incorrectly translated off-screen due to animation classes persisting in its closed state.

The fix involves:
- Removing the `-translate-y-full` transform and associated `transition-transform` from the `InnerDiv` when the menu is in its collapsed (`isMenuOpen = false`) state.
- Ensuring the `InnerDiv` correctly displays with its intended styling (`bg-transparent shadow-lg rounded-lg`) in this state.

This change prioritizes the visibility of the collapsed navbar. The slide-down animation of the full menu content might be affected and may appear differently, but the navbar is now functional and visible in its collapsed state. Individual item stagger animations remain unaffected.