### PR TITLE
Fix: Add message icon to main player bar

### DIFF
--- a/src/components/layout/RadioPageLayout.tsx
+++ b/src/components/layout/RadioPageLayout.tsx
@@ -1,7 +1,7 @@
 import { useState, useRef, ReactNode } from "react";
 import { Link } from "react-router-dom";
 import ReactPlayer from 'react-player';
-import { Play, Pause, SkipBack, SkipForward, Volume2, VolumeX, Heart, Radio } from "lucide-react";
+import { Play, Pause, SkipBack, SkipForward, Volume2, VolumeX, Heart, Radio, MessageCircle } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
 import { Program } from "@/pages/Index";
@@ -56,6 +56,11 @@ const RadioPageLayout: React.FC<RadioPageLayoutProps> = ({
   const handleMessageClick = () => {
     console.log("Message clicked - funzione da implementare");
   };
+
+  const handleMessageClickInBar = () => {
+    console.log("Message clicked in player bar - funzione da implementare");
+  };
+
   const handleMobileMenuClick = (item: string) => {
     console.log(`Menu item clicked: ${item} - funzione da implementare`);
   };
@@ -142,9 +147,12 @@ const RadioPageLayout: React.FC<RadioPageLayoutProps> = ({
             </Button>
           </div>
 
-          <div className={`items-center space-x-4 ${isMobile ? 'hidden' : 'flex'}`}>
+          <div className="flex items-center space-x-4">
             <Button variant="ghost" size="sm" className="text-white hover:bg-white/10">
               <Heart className="w-5 h-5" />
+            </Button>
+            <Button variant="ghost" size="sm" className="text-white hover:bg-white/10" onClick={handleMessageClickInBar}>
+              <MessageCircle className="w-5 h-5" />
             </Button>
             <Button variant="ghost" size="icon" onClick={toggleMute} className="text-white hover:bg-white/10">
               {muted || volume === 0 ? <VolumeX className="w-5 h-5" /> : <Volume2 className="w-5 h-5" />}


### PR DESCRIPTION
This commit addresses your feedback that the message icon was missing from the player bar.

- I added the `MessageCircle` icon next to the `Heart` icon in the main bottom player bar in `src/components/layout/RadioPageLayout.tsx`.
- This group of icons (Like and Message) is now visible on both mobile and desktop views because I adjusted the conditional styling.
- I added a new click handler `handleMessageClickInBar` for the new message icon in the player bar, which currently logs to the console.

The previously existing `PlayerActionIcons` component (mobile-only, floating icons including a message icon) remains unchanged. This might result in duplicate icons on mobile views, which can be addressed in a future iteration if needed.