### PR TITLE
Feat: Update mobile menu styling and animation

### DIFF
--- a/src/components/mobile/MobileNavbar.tsx
+++ b/src/components/mobile/MobileNavbar.tsx
@@ -16,7 +16,7 @@ const MobileNavbar = ({
   };
   const menuItems = ["Live", "Podcast", "Palinsesto", "Chi siamo", "Contatti"];
   return <div className={isMenuOpen ? "md:hidden fixed inset-0 z-50 bg-white flex flex-col" : "md:hidden fixed top-[5px] left-1/2 transform -translate-x-1/2 w-[90%] z-30"}>
-      <div className={isMenuOpen ? 'flex flex-col h-full translate-y-0 transition-transform duration-300 ease-in-out' : 'bg-transparent shadow-lg rounded-lg'}>
+      <div className={isMenuOpen ? 'flex flex-col h-full translate-y-0 transition-transform duration-500 ease-in-out' : 'bg-transparent shadow-lg rounded-lg'}>
         {/* Main navbar */}
         <div className={`flex items-center p-2 ${isMenuOpen ? '' : 'justify-between'}`}>
           <div className={`flex items-center space-x-2 ${isMenuOpen ? 'flex-1' : ''}`}> {/* New wrapper div */}
@@ -37,7 +37,7 @@ const MobileNavbar = ({
         {/* Expandable menu */}
         {isMenuOpen && <div className="border-t border-gray-200 flex-grow overflow-y-auto">
             <div className="py-2">
-              {menuItems.map((item, index) => <button key={index} onClick={() => handleMenuItemClick(item)} style={{ transitionDelay: isMenuOpen ? `${index * 75}ms` : '0ms' }} className={`w-full text-left px-4 py-4 text-gray-800 hover:bg-gray-50 text-base font-medium uppercase border-b border-dotted border-gray-200 last:border-b-0 transition-all duration-300 ease-out ${isMenuOpen ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
+              {menuItems.map((item, index) => <button key={index} onClick={() => handleMenuItemClick(item)} style={{ transitionDelay: isMenuOpen ? `${index * 75}ms` : '0ms' }} className={`w-full text-left px-4 py-6 text-gray-800 hover:bg-gray-50 text-lg font-bold uppercase border-b border-dotted border-gray-200 last:border-b-0 transition-all duration-500 ease-out ${isMenuOpen ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
                   {item}
                 </button>)}
             </div>


### PR DESCRIPTION
This commit implements your requests to enhance the full-page mobile menu:

- Link Styling:
    - Menu links in `src/components/mobile/MobileNavbar.tsx` are now `font-bold` (previously `font-medium`).
    - Font size increased from `text-base` to `text-lg`.
    - Vertical padding increased from `py-4` to `py-6` to make items taller and give a fuller line height.

- Entrance Animation:
    - The animation duration for the main menu container's slide-in effect has been increased from 300ms to 500ms.
    - The animation duration for individual menu items (fade-in/slide-up with stagger) has also been increased from 300ms to 500ms.
    - These changes aim for a "super smooth" entrance animation as you requested.