### PR TITLE
I've integrated the new MobileMenu component and its styles.

### DIFF
--- a/src/components/layout/RadioPageLayout.tsx
+++ b/src/components/layout/RadioPageLayout.tsx
@@ -7,7 +7,7 @@ import { Slider } from "@/components/ui/slider";
 import { Program } from "@/pages/Index";
 import { Playlist } from "@/data/playlists";
 import { useIsMobile } from "@/hooks/use-mobile";
-import MobileNavbar from "@/components/mobile/MobileNavbar";
+import MobileMenu from "@/components/mobile/MobileNavbar";
 import PlayerActionIcons from "@/components/mobile/PlayerActionIcons";
 export interface RadioPageLayoutProps {
   backgroundElement: ReactNode;
@@ -39,6 +39,7 @@ const RadioPageLayout: React.FC<RadioPageLayoutProps> = ({
   const [volume, setVolume] = useState(0.8);
   const [muted, setMuted] = useState(false);
   const isMobile = useIsMobile();
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
   const handleVolumeChange = (newVolume: number[]) => {
     setVolume(newVolume[0]);
     setMuted(false);
@@ -61,8 +62,8 @@ const RadioPageLayout: React.FC<RadioPageLayoutProps> = ({
     console.log("Message clicked in player bar - funzione da implementare");
   };
 
-  const handleMobileMenuClick = (item: string) => {
-    console.log(`Menu item clicked: ${item} - funzione da implementare`);
+  const handleCloseMobileMenu = () => {
+    setIsMobileMenuOpen(false);
   };
   let audioUrl = "";
   let currentTrackTitle = currentProgramForPlayer?.name || "Live Stream";
@@ -90,8 +91,22 @@ const RadioPageLayout: React.FC<RadioPageLayoutProps> = ({
       if (isPlaying) onTogglePlay();
     }} onEnded={handleEnded} />
 
-      {/* Mobile Navbar */}
-      {isMobile && <MobileNavbar onMenuItemClick={handleMobileMenuClick} />}
+      {/* Mobile Menu Toggle Button and Menu */}
+      {isMobile && (
+        <>
+          <div className="fixed top-4 right-4 z-50">
+            <Button
+              onClick={() => setIsMobileMenuOpen(true)}
+              variant="outline" // Changed for better visibility
+              size="icon"
+              className="text-white bg-neutral-900 hover:bg-neutral-700 border-neutral-700" // Style for visibility
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
+            </Button>
+          </div>
+          <MobileMenu isOpen={isMobileMenuOpen} onClose={handleCloseMobileMenu} />
+        </>
+      )}
 
       {/* Desktop Header */}
       {!isMobile && <header className="relative z-10 flex items-center justify-between p-6">

--- a/src/components/mobile/MobileMenu.css
+++ b/src/components/mobile/MobileMenu.css
@@ -1,0 +1,142 @@
+/* MobileMenu.css */
+
+.mobile-menu-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(255, 255, 255, 0.98);
+  backdrop-filter: blur(2px);
+  z-index: 9999;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  opacity: 0;
+  transform: translateY(-100%);
+  transition: all 0.3s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+.mobile-menu-overlay.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.mobile-menu-content {
+  width: 100%;
+  max-width: 100vw;
+  padding: 80px 40px 40px;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.mobile-menu-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  width: 100%;
+  max-width: 480px;
+  margin: 0 auto;
+}
+
+.mobile-menu-item {
+  display: block;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: clamp(28px, 6vw, 42px);
+  font-weight: 400;
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: #000;
+  text-decoration: none;
+  padding: 16px 0;
+  margin: 0;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  position: relative;
+  overflow: hidden;
+
+  /* Animazione stagger */
+  opacity: 0;
+  transform: translateY(30px);
+  animation: slideInStagger 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94) forwards;
+}
+
+.mobile-menu-item:first-child {
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.mobile-menu-item:hover {
+  color: #333;
+}
+
+.mobile-menu-item:active {
+  color: #666;
+}
+
+/* Animazione per il slide-in stagger */
+@keyframes slideInStagger {
+  0% {
+    opacity: 0;
+    transform: translateY(30px);
+  }
+  100% {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Responsive design */
+@media (max-width: 480px) {
+  .mobile-menu-content {
+    padding: 60px 24px 24px;
+  }
+
+  .mobile-menu-item {
+    font-size: clamp(24px, 7vw, 36px);
+    padding: 12px 0;
+  }
+}
+
+@media (max-height: 600px) {
+  .mobile-menu-content {
+    justify-content: flex-start;
+    padding-top: 40px;
+  }
+}
+
+/* Ottimizzazioni per performance */
+.mobile-menu-overlay {
+  will-change: transform, opacity;
+}
+
+.mobile-menu-item {
+  will-change: transform, opacity;
+}
+
+/* Accessibilità */
+@media (prefers-reduced-motion: reduce) {
+  .mobile-menu-overlay,
+  .mobile-menu-item {
+    transition: none;
+    animation: none;
+  }
+
+  .mobile-menu-item {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* Focus states per accessibilità */
+.mobile-menu-item:focus {
+  outline: 2px solid #000;
+  outline-offset: 4px;
+}
+
+.mobile-menu-item:focus-visible {
+  outline: 2px solid #000;
+  outline-offset: 4px;
+}

--- a/src/components/mobile/MobileNavbar.tsx
+++ b/src/components/mobile/MobileNavbar.tsx
@@ -1,48 +1,79 @@
-import { useState } from "react";
-import { Button } from "@/components/ui/button";
-interface MobileNavbarProps {
-  onMenuItemClick?: (item: string) => void;
-}
-const MobileNavbar = ({
-  onMenuItemClick
-}: MobileNavbarProps) => {
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const toggleMenu = () => {
-    setIsMenuOpen(!isMenuOpen);
-  };
-  const handleMenuItemClick = (item: string) => {
-    onMenuItemClick?.(item);
-    setIsMenuOpen(false);
-  };
-  const menuItems = ["Live", "Podcast", "Palinsesto", "Chi siamo", "Contatti"];
-  return <div className={isMenuOpen ? "md:hidden fixed inset-0 z-50 bg-white flex flex-col" : "md:hidden fixed top-[5px] left-1/2 transform -translate-x-1/2 w-[90%] z-30"}>
-      <div className={isMenuOpen ? 'flex flex-col h-full translate-y-0 transition-transform duration-500 ease-in-out' : 'bg-transparent shadow-lg rounded-lg'}>
-        {/* Main navbar */}
-        <div className={`flex items-center p-2 ${isMenuOpen ? '' : 'justify-between'}`}>
-          <div className={`flex items-center space-x-2 ${isMenuOpen ? 'flex-1' : ''}`}> {/* New wrapper div */}
-            <div className="w-12 h-12 bg-white rounded-lg flex items-center justify-center">
-              <img src="https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcR6RFZ_DjLPAbpKy6YRptoo6QFCSVF3PFLNLQ&s" alt="Amblé Radio" className="w-10 h-8 object-contain" />
-            </div>
-            <div className={`${isMenuOpen ? 'text-center flex-1' : 'text-left'}`}> {/* Modified text div */}
-              <span className={isMenuOpen ? 'text-black font-bold text-base' : 'text-white font-bold text-base'}>Amblé Radio</span>
-              <p className={isMenuOpen ? 'text-black text-xs' : 'text-white/70 text-xs'}>Fresh Sound & Podcasts</p>
-            </div>
-          </div>
-          
-          <Button onClick={toggleMenu} variant="ghost" size="sm" className={`font-medium py-1 bg-transparent px-[12px] text-base ${isMenuOpen ? 'text-black' : 'text-white'}`}>
-            {isMenuOpen ? "- CLOSE" : "+ MENU"}
-          </Button>
-        </div>
+import React, { useState, useEffect } from 'react';
+import './MobileMenu.css';
 
-        {/* Expandable menu */}
-        {isMenuOpen && <div className="border-t border-gray-200 flex-grow overflow-y-auto">
-            <div className="py-2">
-              {menuItems.map((item, index) => <button key={index} onClick={() => handleMenuItemClick(item)} style={{ transitionDelay: isMenuOpen ? `${index * 75}ms` : '0ms' }} className={`w-full text-left px-4 py-6 text-gray-800 hover:bg-gray-50 text-lg font-bold uppercase border-b border-dotted border-gray-200 last:border-b-0 transition-all duration-500 ease-out ${isMenuOpen ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-5'}`}>
-                  {item}
-                </button>)}
-            </div>
-          </div>}
+const MobileMenu = ({ isOpen, onClose }) => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [shouldRender, setShouldRender] = useState(false);
+
+  const menuItems = [
+    { label: 'About Friends', href: '#about' },
+    { label: 'Our Mission', href: '#mission' },
+    { label: 'Our Purpose', href: '#purpose' },
+    { label: 'Our Approach', href: '#approach' },
+    { label: 'Our Services', href: '#services' },
+    { label: 'Leadership Team', href: '#leadership' },
+    { label: 'Our Friends', href: '#friends' },
+    { label: 'Team', href: '#team' },
+    { label: 'Past Performance', href: '#performance' },
+    { label: 'Agency', href: '#agency' },
+    { label: 'Our Information', href: '#information' }
+  ];
+
+  useEffect(() => {
+    if (isOpen) {
+      setShouldRender(true);
+      // Piccolo delay per permettere il render prima dell'animazione
+      setTimeout(() => setIsVisible(true), 10);
+    } else {
+      setIsVisible(false);
+      // Delay per permettere l'animazione di uscita prima di rimuovere dal DOM
+      setTimeout(() => setShouldRender(false), 300);
+    }
+  }, [isOpen]);
+
+  const handleClose = () => {
+    onClose();
+  };
+
+  const handleMenuItemClick = (href) => {
+    // Naviga alla sezione
+    window.location.href = href;
+    handleClose();
+  };
+
+  if (!shouldRender) return null;
+
+  return (
+    <div
+      className={`mobile-menu-overlay ${isVisible ? 'visible' : ''}`}
+      onClick={handleClose}
+    >
+      <div
+        className="mobile-menu-content"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <nav className="mobile-menu-nav">
+          {menuItems.map((item, index) => (
+            <a
+              key={item.label}
+              href={item.href}
+              className="mobile-menu-item"
+              style={{
+                animationDelay: isVisible ? `${index * 0.1}s` : '0s',
+                animationDirection: isVisible ? 'normal' : 'reverse'
+              }}
+              onClick={(e) => {
+                e.preventDefault();
+                handleMenuItemClick(item.href);
+              }}
+            >
+              {item.label}
+            </a>
+          ))}
+        </nav>
       </div>
-    </div>;
+    </div>
+  );
 };
-export default MobileNavbar;
+
+export default MobileMenu;


### PR DESCRIPTION
I replaced the existing mobile navigation component with the new MobileMenu component.

Key changes:
- I updated the content of `src/components/mobile/MobileNavbar.tsx` with the new `MobileMenu` React component code.
- I added a new CSS file at `src/components/mobile/MobileMenu.css` containing the styles for the new menu.
- I made some updates to `src/components/layout/RadioPageLayout.tsx`:
    - I changed the import from `MobileNavbar` to `MobileMenu`.
    - I added state management (`isMobileMenuOpen`, `setIsMobileMenuOpen`) for the menu's visibility.
    - I added a `handleCloseMobileMenu` function.
    - I added a new button in the mobile header to toggle the `MobileMenu`.
    - I replaced the old `MobileNavbar` component usage with the new `MobileMenu` component, passing the necessary `isOpen` and `onClose` props.