### PR TITLE
feat: Update image and link for Ad 1

### DIFF
--- a/src/pages/SponsorVideoPage.tsx
+++ b/src/pages/SponsorVideoPage.tsx
@@ -27,8 +27,8 @@ const mockAdvertisements: Advertisement[] = [
   {
     id: "ad1",
     name: "Awesome Product",
-    imageUrl: "https://placehold.co/600x400/E74C3C/FFFFFF/png?text=Ad+1",
-    targetUrl: "https://example.com/product",
+    imageUrl: "https://res.cloudinary.com/thinkdigital/image/upload/v1750257627/images_kj2qyb.png",
+    targetUrl: "https://www.revolut.com/it-IT/",
   },
   {
     id: "ad2",


### PR DESCRIPTION
Updated the image and target URL for the advertisement with id "ad1" in `SponsorVideoPage.tsx`.

The new image is from cloudinary and the link points to revolut.com.