### PR TITLE
Fix: Resolve merge conflict and restore missing menu items

### DIFF
--- a/src/components/mobile/MobileNavbar.tsx
+++ b/src/components/mobile/MobileNavbar.tsx
@@ -11,13 +11,9 @@ const MobileMenu = ({ isOpen, onClose }) => {
     { label: 'Playlist', href: '/playlist' },
     { label: 'Programmi', href: '/programmi' },
     { label: 'Podcast', href: '/podcast' },
-<<<<<feat/desktop-navbar-3col
     { label: 'Chi Siamo', href: '/chi-siamo' },
     { label: 'Pagina Slideshow', href: '/program-slideshow' },
     { label: 'Pagina Video Background', href: '/sponsor-video' }
-
-    { label: 'Chi Siamo', href: '/chi-siamo' }
-main
   ];
 
   useEffect(() => {


### PR DESCRIPTION
I resolved a merge conflict in `src/components/mobile/MobileNavbar.tsx` that was preventing some menu items from displaying.

The 'Pagina Slideshow' and 'Pagina Video Background' links are now visible and functional in the mobile menu.