### PR TITLE
feat: Add PodcastDemo page and empty left columns

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import Index from "./pages/Index";
 import SponsorVideoPage from "./pages/SponsorVideoPage";
 import ProgramSponsorSlideshowPage from "./pages/ProgramSponsorSlideshowPage";
 import PlaylistPage from "./pages/PlaylistPage"; // Import the new PlaylistPage
+import PodcastDemoPage from "./pages/PodcastDemoPage"; // Import the new PodcastDemoPage
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -22,6 +23,7 @@ const App = () => (
           <Route path="/sponsor-video" element={<SponsorVideoPage />} />
           <Route path="/program-slideshow" element={<ProgramSponsorSlideshowPage />} />
           <Route path="/playlist" element={<PlaylistPage />} />
+          <Route path="/podcast-demo" element={<PodcastDemoPage />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -137,51 +137,7 @@ const Index = () => {
     >
       {/* Children: Left and Right Sidebars passed to the layout */}
       <div className="w-1/4 grid grid-cols-2 gap-4">
-        {/* Current Show Card */}
-        <Card className="col-span-2 bg-black/30 backdrop-blur-lg border-white/10 p-4 flex flex-col justify-between">
-          <div>
-            <div className="flex items-center space-x-2 mb-2">
-              <div className="w-2 h-2 bg-red-500 rounded-full animate-pulse"></div>
-              <span className="text-red-400 text-xs font-medium">LIVE NOW</span>
-            </div>
-            <h2 className="text-white text-xl font-bold mb-1">{currentProgram ? currentProgram.name : "Loading..."}</h2>
-            <p className="text-white/70 text-sm mb-2">with {currentProgram ? currentProgram.host : "..."}</p>
-            <p className="text-white/60 text-xs">Broadcasting live with the latest hits and talks.</p>
-          </div>
-          <div className="flex items-center justify-between mt-4">
-            <Button
-              onClick={togglePlay}
-              className="w-12 h-12 rounded-full bg-gradient-to-r from-pink-500 to-orange-500 hover:from-pink-600 hover:to-orange-600"
-            >
-              {isPlaying ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4 ml-0.5" />}
-            </Button>
-            <div className="text-white flex-1 ml-3">
-              <p className="text-xs opacity-70">Now Playing</p>
-              <p className="font-medium text-sm">Tame Impala</p> {/* Placeholder */}
-            </div>
-          </div>
-        </Card>
-
-        {/* Popular Podcasts Card */}
-        <Card className="col-span-2 bg-black/30 backdrop-blur-lg border-white/10 p-3">
-          <h3 className="text-white font-semibold mb-3 text-sm">Popular Podcasts</h3>
-          <div className="grid grid-cols-2 gap-2">
-            <div className="bg-white/5 rounded-lg p-2 hover:bg-white/10 transition-colors cursor-pointer">
-              <div className="w-full h-12 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg mb-1">
-                <img className="rounded-lg" src="https://placehold.co/400x100/cccccc/FFFFFF/png" />
-              </div>
-              <p className="text-white text-xs font-medium">Tech & Innovation</p>
-              <p className="text-white/60 text-xs">24 ep</p>
-            </div>
-            <div className="bg-white/5 rounded-lg p-2 hover:bg-white/10 transition-colors cursor-pointer">
-              <div className="w-full h-12 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg mb-1">
-                <img className="rounded-lg" src="https://placehold.co/400x100/cccccc/FFFFFF/png" />
-              </div>
-              <p className="text-white text-xs font-medium">Culture & Arts</p>
-              <p className="text-white/60 text-xs">18 ep</p>
-            </div>
-          </div>
-        </Card>
+        {/* This left column is now empty as per user request */}
       </div>
 
       <div className="w-1/4 grid grid-cols-1 md:grid-cols-2 gap-4">

--- a/src/pages/PodcastDemoPage.tsx
+++ b/src/pages/PodcastDemoPage.tsx
@@ -1,0 +1,85 @@
+import { useState, useEffect } from "react";
+import { Play, Pause } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card"; // Keep Card for potential use in right column
+import RadioPageLayout from "@/components/layout/RadioPageLayout";
+import { Program } from "./Index"; // Re-use Program interface
+
+const PODCAST_TITLE = "Monicelli e Moretti Due Generazioni a Confronto";
+const PODCAST_AUDIO_URL = "https://res.cloudinary.com/thinkdigital/video/upload/v1750623353/Monicelli_e_Moretti__Due_Generazioni_a_Confronto_jh37ll.wav";
+const YOUTUBE_VIDEO_ID = "AIdMhQjCEeU";
+
+const PodcastDemoPage = () => {
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [podcastProgram, setPodcastProgram] = useState<Program | null>(null);
+
+  useEffect(() => {
+    setPodcastProgram({
+      id: "podcast1",
+      name: PODCAST_TITLE,
+      host: "Podcast", // Artist/Host for the podcast
+      imageUrl: "", // No specific image for podcast, background is video
+      audioUrl: PODCAST_AUDIO_URL,
+    });
+  }, []);
+
+  const togglePlay = () => {
+    setIsPlaying(prev => !prev);
+  };
+
+  const backgroundVideoElement = (
+    <iframe
+      src={`https://www.youtube.com/embed/${YOUTUBE_VIDEO_ID}?autoplay=1&loop=1&playlist=${YOUTUBE_VIDEO_ID}&mute=1&controls=0&showinfo=0&autohide=1&modestbranding=1`}
+      frameBorder="0"
+      allow="autoplay; encrypted-media; gyroscope; picture-in-picture"
+      allowFullScreen
+      style={{
+        position: 'absolute',
+        width: '100%',
+        height: '100%',
+        objectFit: 'cover',
+        top: 0,
+        left: 0,
+        pointerEvents: 'none', // Prevents iframe from capturing mouse events
+      }}
+      title="Podcast Background Video"
+    ></iframe>
+  );
+
+  // No header actions needed for this page based on requirements
+  const headerActionButtons = null;
+
+  return (
+    <RadioPageLayout
+      backgroundElement={backgroundVideoElement}
+      currentProgramForPlayer={podcastProgram} // This will provide audioUrl to the layout's player
+      headerActions={headerActionButtons}
+      isPlaying={isPlaying}
+      onTogglePlay={togglePlay} // Connects layout's play/pause to this page's state
+    >
+      {/* Left column is empty, consistent with other pages */}
+      <div className="w-1/4">
+        {/* Empty left column */}
+      </div>
+
+      {/* Right Column: Podcast Player Card */}
+      <div className="w-1/4 flex flex-col items-center justify-center"> {/* Simplified right column for the podcast player */}
+        <Card className="bg-black/30 backdrop-blur-lg border-white/10 p-6 w-full max-w-md">
+          <div className="flex flex-col items-center space-y-4">
+            <h2 className="text-white text-2xl font-bold text-center">{PODCAST_TITLE}</h2>
+            <p className="text-white/70 text-sm">Click play to listen</p>
+            <Button
+              onClick={togglePlay}
+              className="w-16 h-16 rounded-full bg-gradient-to-r from-pink-500 to-orange-500 hover:from-pink-600 hover:to-orange-600 text-white"
+              size="icon"
+            >
+              {isPlaying ? <Pause size={32} /> : <Play size={32} className="ml-1" />}
+            </Button>
+          </div>
+        </Card>
+      </div>
+    </RadioPageLayout>
+  );
+};
+
+export default PodcastDemoPage;

--- a/src/pages/SponsorVideoPage.tsx
+++ b/src/pages/SponsorVideoPage.tsx
@@ -113,50 +113,9 @@ const SponsorVideoPage = () => {
       isPlaying={isPlaying}
       onTogglePlay={togglePlay}
     >
-      {/* Copied Sidebar Content from Index.tsx - This should ideally be componentized further in a real app */}
+      {/* Left column is now empty as per user request */}
       <div className="w-1/4 grid grid-cols-2 gap-4">
-        <Card className="col-span-2 bg-black/30 backdrop-blur-lg border-white/10 p-4 flex flex-col justify-between">
-          <div>
-            <div className="flex items-center space-x-2 mb-2">
-              <div className="w-2 h-2 bg-red-500 rounded-full animate-pulse"></div>
-              <span className="text-red-400 text-xs font-medium">LIVE NOW</span>
-            </div>
-            <h2 className="text-white text-xl font-bold mb-1">{currentProgram ? currentProgram.name : "Loading..."}</h2>
-            <p className="text-white/70 text-sm mb-2">with {currentProgram ? currentProgram.host : "..."}</p>
-            <p className="text-white/60 text-xs">Broadcasting live with the latest hits and talks.</p>
-          </div>
-          <div className="flex items-center justify-between mt-4">
-            <Button
-              onClick={togglePlay}
-              className="w-12 h-12 rounded-full bg-gradient-to-r from-pink-500 to-orange-500 hover:from-pink-600 hover:to-orange-600"
-            >
-              {isPlaying ? <Pause className="w-4 h-4" /> : <Play className="w-4 h-4 ml-0.5" />}
-            </Button>
-            <div className="text-white flex-1 ml-3">
-              <p className="text-xs opacity-70">Now Playing</p>
-              <p className="font-medium text-sm">Sponsor Page Player</p>
-            </div>
-          </div>
-        </Card>
-        <Card className="col-span-2 bg-black/30 backdrop-blur-lg border-white/10 p-3">
-          <h3 className="text-white font-semibold mb-3 text-sm">Popular Podcasts</h3>
-          <div className="grid grid-cols-2 gap-2">
-            <div className="bg-white/5 rounded-lg p-2 hover:bg-white/10 transition-colors cursor-pointer">
-              <div className="w-full h-12 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg mb-1">
-                <img className="rounded-lg" src="https://placehold.co/400x100/cccccc/FFFFFF/png" alt="Tech Podcast" />
-              </div>
-              <p className="text-white text-xs font-medium">Tech & Innovation</p>
-              <p className="text-white/60 text-xs">24 ep</p>
-            </div>
-            <div className="bg-white/5 rounded-lg p-2 hover:bg-white/10 transition-colors cursor-pointer">
-              <div className="w-full h-12 bg-gradient-to-br from-blue-500 to-purple-600 rounded-lg mb-1">
-                <img className="rounded-lg" src="https://placehold.co/400x100/cccccc/FFFFFF/png" alt="Culture Podcast" />
-              </div>
-              <p className="text-white text-xs font-medium">Culture & Arts</p>
-              <p className="text-white/60 text-xs">18 ep</p>
-            </div>
-          </div>
-        </Card>
+        {/* This left column is now empty as per user request */}
       </div>
       <div className="w-1/4 grid grid-cols-1 md:grid-cols-2 gap-4">
         {currentAdvertisement && (


### PR DESCRIPTION
- Adds a new PodcastDemoPage with a YouTube video background and podcast audio playback.
- The podcast audio is controlled by a dedicated button and the main site player.
- Modifies IndexPage and SponsorVideoPage to have an empty left content column as per request.
- PlaylistPage left column remains unchanged as it serves a different, essential function.
- Adds routing for the new PodcastDemoPage.