### PR TITLE
feat: Create new home page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import NewHomePage from "./pages/NewHomePage"; // Import the new home page
 import SponsorVideoPage from "./pages/SponsorVideoPage";
 import ProgramSponsorSlideshowPage from "./pages/ProgramSponsorSlideshowPage";
 import PlaylistPage from "./pages/PlaylistPage";
@@ -22,6 +23,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/new-home" element={<NewHomePage />} /> {/* Add route for the new home page */}
           <Route path="/sponsor-video" element={<SponsorVideoPage />} />
           <Route path="/program-slideshow" element={<ProgramSponsorSlideshowPage />} />
           <Route path="/playlist" element={<PlaylistPage />} />

--- a/src/components/music/PlayerBar.tsx
+++ b/src/components/music/PlayerBar.tsx
@@ -1,0 +1,118 @@
+import { Play, Pause, SkipBack, SkipForward, Volume2, VolumeX, Heart, MessageCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Slider } from "@/components/ui/slider";
+import { useState } from "react";
+
+interface PlayerBarProps {
+  // Define props needed for the player bar, e.g.,
+  // isPlaying: boolean;
+  // onPlayPause: () => void;
+  // onNext: () => void;
+  // onPrevious: () => void;
+  // volume: number;
+  // onVolumeChange: (volume: number) => void;
+  // currentSongTitle?: string;
+  // currentArtist?: string;
+}
+
+const PlayerBar: React.FC<PlayerBarProps> = (
+  {
+    /* Destructure props here */
+  }
+) => {
+  // Example state - replace with props or more robust state management
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [volume, setVolume] = useState(0.8);
+  const [muted, setMuted] = useState(false);
+
+  const togglePlay = () => setIsPlaying(!isPlaying);
+  const handleVolumeChange = (newVolume: number[]) => {
+    setVolume(newVolume[0]);
+    setMuted(false);
+  };
+  const toggleMute = () => {
+    const newMuted = !muted;
+    setMuted(newMuted);
+    if (!newMuted && volume === 0) {
+      setVolume(0.5); // Unmute to a default volume
+    }
+  };
+
+  // Placeholder functions for skip actions
+  const handleNext = () => console.log("Next track");
+  const handlePrevious = () => console.log("Previous track");
+
+  // Placeholder data - replace with props
+  const currentSongTitle = "Free Fall (Visualizer) (feat. J. Cole)";
+  const currentArtist = "Tems • Born in the Wild • 2024 • 4:15";
+
+  return (
+    <div className="bg-black/50 backdrop-blur-md p-4 rounded-lg mt-4">
+      {" "}
+      {/* Added mt-4 for spacing, adjust as needed */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center space-x-3">
+          <img
+            src="https://res.cloudinary.com/thinkdigital/image/upload/v1748272704/pexels-isabella-mendes-107313-860707_qjh3q1.jpg" // Replace with actual album art prop
+            alt="Album art"
+            className="w-12 h-12 rounded"
+          />
+          <div>
+            <p className="text-white font-semibold text-sm truncate w-48" title={currentSongTitle}>
+              {currentSongTitle}
+            </p>
+            <p className="text-gray-400 text-xs truncate w-48" title={currentArtist}>
+              {currentArtist}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center space-x-2 sm:space-x-4">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-gray-400 hover:text-white"
+            onClick={handlePrevious}
+          >
+            <SkipBack className="w-5 h-5" />
+          </Button>
+          <Button
+            onClick={togglePlay}
+            className="w-10 h-10 sm:w-12 sm:h-12 rounded-full bg-white text-black hover:bg-white/90 flex items-center justify-center"
+          >
+            {isPlaying ? <Pause className="w-5 h-5 sm:w-6 sm:h-6" /> : <Play className="w-5 h-5 sm:w-6 sm:h-6 ml-0.5" />}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-gray-400 hover:text-white"
+            onClick={handleNext}
+          >
+            <SkipForward className="w-5 h-5" />
+          </Button>
+        </div>
+
+        <div className="hidden sm:flex items-center space-x-2">
+          <Button variant="ghost" size="icon" className="text-gray-400 hover:text-white">
+            <Heart className="w-4 h-4" />
+          </Button>
+          <Button variant="ghost" size="icon" className="text-gray-400 hover:text-white">
+            <MessageCircle className="w-4 h-4" />
+          </Button>
+          <Button variant="ghost" size="icon" onClick={toggleMute} className="text-gray-400 hover:text-white">
+            {muted || volume === 0 ? <VolumeX className="w-5 h-5" /> : <Volume2 className="w-5 h-5" />}
+          </Button>
+          <Slider
+            value={[muted ? 0 : volume]}
+            onValueChange={handleVolumeChange}
+            max={1}
+            step={0.01}
+            className="w-20 h-1 bg-gray-700 rounded-full [&>span:first-child]:bg-white"
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PlayerBar;

--- a/src/pages/NewHomePage.tsx
+++ b/src/pages/NewHomePage.tsx
@@ -1,0 +1,185 @@
+import { useState, useEffect } from "react";
+// ReactPlayer and its specific controls (Slider, VolumeX, SkipBack, SkipForward, Volume2) are moved to RadioPageLayout
+import { Play, Pause, Heart, Mic, Radio, Users, Clock } from "lucide-react"; // Keep icons used in Index's direct children
+import { Button } from "@/components/ui/button";
+// import { Card } from "@/components/ui/card"; // Card is not used in the new layout
+import RadioPageLayout from "@/components/layout/RadioPageLayout"; // Import the new layout
+import LyricsPanel from "@/components/music/LyricsPanel";
+import RelatedVideos from "@/components/music/RelatedVideos";
+import PlayerBar from "@/components/music/PlayerBar"; // Assuming PlayerBar component will be created
+
+// Define Interfaces (Export them)
+export interface Program {
+  id: string;
+  name: string;
+  host: string;
+  imageUrl: string;
+  audioUrl: string;
+}
+
+export interface Advertisement {
+  id: string;
+  name: string;
+  imageUrl: string;
+  videoUrl?: string;
+  targetUrl: string;
+}
+
+// Mock Data
+export const mockPrograms: Program[] = [
+  {
+    id: "program1",
+    name: "Morning Vibes",
+    host: "Marco & Sofia",
+    imageUrl: "https://res.cloudinary.com/thinkdigital/image/upload/v1748272704/pexels-isabella-mendes-107313-860707_qjh3q1.jpg",
+    audioUrl: "https://mqugxowc-lbmedia.radioca.st/stream?type=http&nocache=43",
+  },
+  {
+    id: "program2",
+    name: "Tech Talk",
+    host: "Alessandro R.",
+    imageUrl: "https://images.pexels.com/photos/3861958/pexels-photo-3861958.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
+    audioUrl: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3",
+  },
+  {
+    id: "program3",
+    name: "Lunch Beats",
+    host: "DJ Luna",
+    imageUrl: "https://images.pexels.com/photos/1762578/pexels-photo-1762578.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
+    audioUrl: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3",
+  },
+];
+
+export const mockAdvertisements: Advertisement[] = [
+  {
+    id: "ad1",
+    name: "Awesome Product",
+    imageUrl: "https://placehold.co/600x400/E74C3C/FFFFFF/png?text=Ad+1",
+    targetUrl: "https://example.com/product",
+  },
+  {
+    id: "ad2",
+    name: "Amazing Service",
+    imageUrl: "https://placehold.co/600x400/3498DB/FFFFFF/png?text=Ad+2",
+    videoUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
+    targetUrl: "https://example.com/service",
+  },
+];
+
+const NewHomePage = () => {
+  const [isPlaying, setIsPlaying] = useState(false); // Controls UI elements in Index & passed to layout
+  const [currentBackgroundImage, setCurrentBackgroundImage] = useState("https://res.cloudinary.com/thinkdigital/image/upload/v1748272704/pexels-isabella-mendes-107313-860707_qjh3q1.jpg");
+  const [currentProgram, setCurrentProgram] = useState<Program | null>(null);
+  // const [currentAdvertisement, setCurrentAdvertisement] = useState<Advertisement | null>(mockAdvertisements[0]); // Advertisement not used in new layout
+  // playerRef, volume, muted, handleVolumeChange, toggleMute are now managed by RadioPageLayout
+
+  const togglePlay = () => {
+    setIsPlaying(prev => !prev); // This function is passed to layout as onTogglePlay
+  };
+
+  const setBackground = (url: string) => {
+    setCurrentBackgroundImage(url);
+  };
+
+  const setCurrentProgramById = (id: string) => {
+    const program = mockPrograms.find(p => p.id === id);
+    if (program) {
+      setCurrentProgram(program);
+    }
+  };
+
+  // const setCurrentAdvertisementById = (id: string) => { // Advertisement not used in new layout
+  //   const ad = mockAdvertisements.find(a => a.id === id);
+  //   if (ad) {
+  //     setCurrentAdvertisement(ad);
+  //   }
+  // };
+
+  useEffect(() => {
+    // Set initial program when component mounts
+    if (mockPrograms.length > 0 && !currentProgram) { // Ensure it only sets if not already set
+      setCurrentProgram(mockPrograms[0]);
+    }
+  }, [currentProgram]); // Add currentProgram to dependency array to prevent re-setting if it's already set by other means.
+
+  useEffect(() => {
+    if (currentProgram) {
+      // For the new layout, we might not want to change the main background image based on program,
+      // as the main content area has its own image.
+      // If a specific background for RadioPageLayout is still desired, this can be adjusted.
+      // setBackground(currentProgram.imageUrl);
+    }
+  }, [currentProgram]);
+
+  // useEffect(() => { // Advertisement not used in new layout
+  //   if (currentAdvertisement && currentAdvertisement.videoUrl) {
+  //     console.log("Current advertisement has video: ", currentAdvertisement.videoUrl);
+  //   }
+  // }, [currentAdvertisement]);
+
+  // const headerActionButtons = ( // Header actions not specified for the new page
+  //   <>
+  //     <Button onClick={() => setCurrentProgramById("program2")} className="text-white hover:bg-white/10">Set P2</Button>
+  //     <Button onClick={() => setCurrentProgramById("program3")} className="text-white hover:bg-white/10">Set P3</Button>
+  //     <Button onClick={() => setCurrentAdvertisementById("ad1")} className="text-white hover:bg-white/10">Set Ad1</Button>
+  //     <Button onClick={() => setCurrentAdvertisementById("ad2")} className="text-white hover:bg-white/10">Set Ad2</Button>
+  //   </>
+  // );
+
+  return (
+    <RadioPageLayout
+      backgroundElement={
+        // The main content will have its own background, so this might not be needed or could be a generic one.
+        // For now, let's keep it simple and rely on the main content's background.
+        // Or, we can set a default, less prominent background for the overall page layout.
+        <div
+          className="absolute inset-0 w-full h-full bg-gradient-to-br from-neutral-800 to-neutral-900"
+        />
+      }
+      currentProgramForPlayer={currentProgram}
+      // headerActions={headerActionButtons} // Header actions not specified for the new page
+      isPlaying={isPlaying}
+      onTogglePlay={togglePlay}
+    >
+      <main className="p-4 h-full flex flex-col text-white"> {/* Added text-white for default text color */}
+        <div className="flex justify-between text-gray-400 mb-4">
+          <span>Minimize</span>
+          <span>Full Screen</span>
+        </div>
+        <div className="flex flex-grow space-x-4 overflow-hidden">
+          <div className="relative flex-1">
+            <img src="https://res.cloudinary.com/thinkdigital/image/upload/v1748272704/pexels-isabella-mendes-107313-860707_qjh3q1.jpg" className="w-full h-full object-cover rounded-lg" />
+            <div className="absolute bottom-4 left-4 bg-black/60 p-4 rounded-lg">
+              <p className="text-sm text-gray-300">Song</p>
+              <h2 className="font-semibold">Free Fall (Visualizer) (feat. J. Cole)</h2>
+              <p className="text-xs text-gray-400">Tems • Born in the Wild • 2024 • 4:15</p>
+            </div>
+          </div>
+          <div className="w-2/5 flex flex-col space-y-4">
+            <LyricsPanel />
+            <RelatedVideos />
+          </div>
+        </div>
+        {/* PlayerBar will be part of the RadioPageLayout's fixed bottom player,
+            so it's not placed here directly. The task asks to keep header and player,
+            which implies using the existing RadioPageLayout's player.
+            If a *new* PlayerBar component is meant to replace RadioPageLayout's player,
+            that's a bigger change to RadioPageLayout itself.
+            For now, assuming the user means the main content area should include these elements,
+            and the existing player in RadioPageLayout remains.
+            The request "il resto inserisci questo codice nel main" suggests this new JSX
+            is the *child* of RadioPageLayout.
+            The PlayerBar mentioned in the user's code snippet might be a conceptual placeholder
+            or they intend for it to be a new, separate component *within* this main content area,
+            distinct from the main site-wide player. Let's assume the latter for now.
+            If `PlayerBar` is meant to be the site-wide player, it should not be here.
+            Given the plan step "Create a new file src/components/music/PlayerBar.tsx",
+            it seems a new, perhaps distinct, player component is intended.
+        */}
+        <PlayerBar /> {/* Using the new PlayerBar component as per user's code and plan */}
+      </main>
+    </RadioPageLayout>
+  );
+};
+
+export default NewHomePage;


### PR DESCRIPTION
- Created NewHomePage.tsx with a new layout as specified.
- The new page keeps the existing header and main player from RadioPageLayout.
- Added LyricsPanel, RelatedVideos, and a new PlayerBar component to the main content area of the new page.
- Added a route /new-home for the new page.