### PR TITLE
feat: Add link to new home page in navbar

### DIFF
--- a/src/components/layout/RadioPageLayout.tsx
+++ b/src/components/layout/RadioPageLayout.tsx
@@ -171,6 +171,11 @@ const RadioPageLayout: React.FC<RadioPageLayoutProps> = ({
                   Podcast Demo
                 </Button>
               </Link>
+              <Link to="/new-home">
+                <Button variant="ghost" className="text-white hover:bg-white/10">
+                  New Home
+                </Button>
+              </Link>
               <Button variant="ghost" className="text-white hover:bg-white/10">
                 Chi Siamo
               </Button>


### PR DESCRIPTION
- Added a 'New Home' link to the main desktop navigation bar.
- This link points to the recently created /new-home route.