### PR TITLE
fix: Correct Play/Pause icon visibility and review player styling

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -194,7 +194,7 @@ const PlayerFooterContent: React.FC = () => {
 
 const MainLayoutContent: React.FC<MainLayoutProps> = ({ children }) => {
   const { currentTrack, isPlaying, volume, muted, loop } = usePlayerState();
-  const { handleProgress, handleDuration, handleEnded } = usePlayerActions();
+  const { handleProgress, handleDuration, handleEnded, handleError } = usePlayerActions(); // Import handleError
   const playerRef = useRef<ReactPlayer>(null);
 
   // Sync playerRef with context if needed, though direct control is via context actions
@@ -235,7 +235,7 @@ const MainLayoutContent: React.FC<MainLayoutProps> = ({ children }) => {
           onEnded={handleEnded}
           onPlay={() => console.log("ReactPlayer: onPlay event. Context isPlaying:", isPlaying, "URL:", currentTrack?.audioUrl)}
           onPause={() => console.log("ReactPlayer: onPause event. Context isPlaying:", isPlaying)}
-          onError={(e) => console.error('ReactPlayer Error:', e, 'Attempted URL:', currentTrack?.audioUrl)}
+          onError={handleError} // Use context's handleError
           width="0"
           height="0"
           config={{ file: { forceAudio: true } }} // Ensures it's treated as audio

--- a/src/contexts/PlayerContext.tsx
+++ b/src/contexts/PlayerContext.tsx
@@ -39,6 +39,7 @@ interface PlayerActions {
   handleProgress: (progress: { playedSeconds: number; loadedSeconds: number }) => void;
   handleDuration: (duration: number) => void;
   handleEnded: () => void;
+  handleError: (error: any) => void; // Add error handler
   nextTrack: () => void;
   prevTrack: () => void;
 }
@@ -174,9 +175,14 @@ export const PlayerProvider: React.FC<PlayerProviderProps> = ({ children }) => {
       // This handleEnded is more for custom behavior like "play next then stop" or single track loop.
     } else if (playerMode === 'live') {
       console.log("Live stream ended or was interrupted.");
-      setIsPlaying(false);
+       setIsPlaying(false); // Stop playing if live stream ends
     }
   }, [playerMode, loop, nextTrackInternal, currentPlaylistTracks.length]);
+
+  const handleError = useCallback((error: any) => {
+    console.error("PlayerContext: ReactPlayer error:", error);
+    setIsPlaying(false); // Set isPlaying to false on error
+  }, []);
 
 
   // Load a default stream on mount
@@ -218,6 +224,7 @@ export const PlayerProvider: React.FC<PlayerProviderProps> = ({ children }) => {
     handleProgress,
     handleDuration,
     handleEnded,
+    handleError, // Add handleError to actions
     nextTrack,
     prevTrack,
   };


### PR DESCRIPTION
- Ensured PlayerContext sets isPlaying to false when ReactPlayer encounters an error, correctly updating the Play/Pause icon.
- Reviewed player styling; no specific CSS changes were copied from PlaylistPage as it didn't have a distinct player component.
- Global player style in MainLayout is deemed adequate.