### PR TITLE
style: Apply requested styles to player and refine Play/Pause icon logic

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -111,6 +111,8 @@ const PlayerFooterContent: React.FC = () => {
   const { togglePlay, setVolume, toggleMute, seekTo, nextTrack, prevTrack } = usePlayerActions();
   const isMobile = useIsMobile();
 
+  console.log('PlayerFooterContent rendering, isPlaying:', isPlaying, 'currentTrack:', currentTrack?.title);
+
 
   const formatTime = (seconds: number) => {
     const date = new Date(0);
@@ -119,12 +121,12 @@ const PlayerFooterContent: React.FC = () => {
   };
 
   return (
-    // Removed: "fixed bottom-0 left-0 right-0 z-30"
-    // Added: "mt-auto" to push to bottom of flex container if content is short, basic padding/margin for spacing
-    <div className="bg-neutral-800/70 backdrop-blur-md border-t border-neutral-700 p-3 text-white w-full mt-auto">
+    // Apply requested styles: bg-black/80 backdrop-blur-xl border-t border-white/10 p-4
+    // Retain w-full and mt-auto for positioning within the flex layout. z-20 omitted as it's in normal flow.
+    <div className="bg-black/80 backdrop-blur-xl border-t border-white/10 p-4 text-white w-full mt-auto">
       <div className="max-w-7xl mx-auto flex items-center justify-between">
         {/* Left: Track Info & Progress Bar */}
-        <div className="flex items-center space-x-3 w-1/3 min-w-0"> {/* Added min-w-0 for better truncation handling */}
+        <div className="flex items-center space-x-3 w-1/3 min-w-0">
           {currentTrack?.imageUrl && (
             <img src={currentTrack.imageUrl} alt={currentTrack.title} className="w-10 h-10 rounded object-cover" />
           )}

--- a/src/pages/NewHomePage.tsx
+++ b/src/pages/NewHomePage.tsx
@@ -21,15 +21,22 @@ const NewHomePage: React.FC = () => {
   // This logic might be better suited in PlayerProvider for a truly global default,
   // or if NewHomePage is THE landing page that should always start a stream.
   useEffect(() => {
-    // If no track is playing OR if the current track is not a live stream, play the default live stream.
-    // This makes sure the homepage always tries to play live content.
-    if (mockPrograms.length > 0 && (!currentTrack || currentTrack.playerMode !== 'live')) {
-      // Check if mockPrograms[0] is already the current track to avoid restarting it if it was just paused.
-      if (!currentTrack || currentTrack.id !== mockPrograms[0].id || currentTrack.playerMode !== 'live') {
-        console.log("NewHomePage: Setting default live stream mockPrograms[0]");
-        playStream(mockPrograms[0]);
+    const defaultLiveProgram = mockPrograms[0];
+    if (defaultLiveProgram) {
+      // If no track is currently set, OR
+      // if a track is set but it's NOT the default live program, OR
+      // if a track is set, IS the default live program, but is NOT in 'live' mode (e.g. error/stalled state changed mode)
+      // THEN, set (or reset) to the default live stream.
+      // This ensures that navigating to the homepage attempts to play the live stream.
+      // PlayerContext's playStream action sets isPlaying to true.
+      if (!currentTrack || currentTrack.id !== defaultLiveProgram.id || currentTrack.playerMode !== 'live') {
+        console.log("NewHomePage useEffect: Setting/Resetting to default live stream.");
+        playStream(defaultLiveProgram);
       }
     }
+    // This effect depends on currentTrack. If currentTrack changes to something else (e.g. user plays a playlist),
+    // and then they navigate back to NewHomePage, this effect will re-evaluate.
+    // playStream is memoized, so it won't cause loops unless currentTrack changes in a way that re-triggers the condition.
   }, [currentTrack, playStream]);
 
   // Use currentTrack from context for display


### PR DESCRIPTION
- Updated player UI container classes in MainLayout.tsx as per request (bg-black/80, backdrop-blur-xl, etc.).
- Refined useEffect in NewHomePage.tsx to better manage setting the default live stream, preventing conflicts with user pause actions.
- This, along with previous PlayerContext.handleError, should ensure the Play/Pause icon correctly reflects the player state.