### PR TITLE
fix: Further debug Play/Pause icon and apply player styles

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -146,7 +146,7 @@ const PlayerFooterContent: React.FC = () => {
               </Button>
             )}
             <Button onClick={togglePlay} className="w-10 h-10 sm:w-12 sm:h-12 rounded-full bg-white text-black hover:bg-white/90 flex items-center justify-center">
-              {isPlaying ? <Pause className="w-5 h-5 sm:w-6 sm:h-6" /> : <Play className="w-5 h-5 sm:w-6 sm:h-6" />} {/* Removed ml-0.5 from Play icon for testing */}
+              {isPlaying ? <Pause className="w-5 h-5 sm:w-6 sm:h-6" /> : <Play className="w-5 h-5 sm:w-6 sm:h-6" />}
             </Button>
             {/* DEBUG: Display isPlaying state */}
             <span className="text-xs text-cyan-400 ml-2">DBG: isPlaying: {isPlaying.toString()}</span>


### PR DESCRIPTION
- Applied requested Tailwind CSS classes to the player UI container.
- Conducted extensive debugging for the Play/Pause icon issue:
  - Added detailed logging for `isPlaying` state changes in PlayerContext and PlayerFooterContent.
  - Added a UI span to display `isPlaying` boolean directly.
  - Performed tests by replacing icons with text and alternate icons to isolate the issue.
- Restored the original Play/Pause icons. If the Play icon still doesn't appear when `isPlaying` is false (as confirmed by logs/debug UI), the issue is likely external (CSS, cache, or lucide-react Play icon specific problem).