### PR TITLE
diag: Drastically simplify mockData.ts for syntax error diagnosis

### DIFF
--- a/src/data/mockData.ts
+++ b/src/data/mockData.ts
@@ -14,43 +14,23 @@ export interface Advertisement {
   targetUrl: string;
 }
 
+// Drastically simplified for diagnostics
 export const mockPrograms: Program[] = [
-  // Force re-typing the first object to clear potential hidden characters/syntax issues
   {
-    id: "program1",
-    name: "Morning Vibes",
-    host: "Marco & Sofia",
-    imageUrl: "https://res.cloudinary.com/thinkdigital/image/upload/v1748272704/pexels-isabella-mendes-107313-860707_qjh3q1.jpg",
-    audioUrl: "https://mqugxowc-lbmedia.radioca.st/stream?type=http&nocache=43",
-  },
-  {
-    id: "program2", // Ensuring comma is here for consistency if more props were added
-    name: "Tech Talk",
-    host: "Alessandro R.",
-    imageUrl: "https://images.pexels.com/photos/3861958/pexels-photo-3861958.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
-    audioUrl: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3",
-  },
-  {
-    id: "program3",
-    name: "Lunch Beats", // Added a third program for more variety
-    host: "DJ Luna",
-    imageUrl: "https://images.pexels.com/photos/1762578/pexels-photo-1762578.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
-    audioUrl: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3",
-  },
+    id: "p1",
+    name: "Test Program One",
+    host: "Test Host One",
+    imageUrl: "http://example.com/image1.jpg",
+    audioUrl: "http://example.com/audio1.mp3",
+  }
 ];
 
+// Drastically simplified for diagnostics
 export const mockAdvertisements: Advertisement[] = [
   {
     id: "ad1",
-    name: "Awesome Product",
-    imageUrl: "https://placehold.co/600x400/E74C3C/FFFFFF/png?text=Ad+1",
-    targetUrl: "https://example.com/product",
-  },
-  {
-    id: "ad2",
-    name: "Amazing Service",
-    imageUrl: "https://placehold.co/600x400/3498DB/FFFFFF/png?text=Ad+2",
-    videoUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
-    targetUrl: "https://example.com/service",
-  },
+    name: "Test Ad One",
+    imageUrl: "http://example.com/adimage1.jpg",
+    targetUrl: "http://example.com/adtarget1",
+  }
 ];


### PR DESCRIPTION
- Temporarily simplified the content of `mockPrograms` and `mockAdvertisements` in `src/data/mockData.ts` to a bare minimum.
- This is a diagnostic step to help isolate a persistent syntax error. The goal is to see if this ultra-simple version parses correctly in the user's build environment.
- Further steps will depend on the outcome of this test.