### PR TITLE
Fix: Ensure homepage background is visible

### DIFF
--- a/src/components/ConceptHomePage.tsx
+++ b/src/components/ConceptHomePage.tsx
@@ -6,7 +6,7 @@ const ConceptHomePage: React.FC = () => {
     <div className="h-full flex flex-col lg:flex-row relative mx-auto px-4 lg:px-8">
       {/* Full Background Image */}
       <div 
-        className="fixed top-0 left-0 w-full h-full bg-cover bg-center bg-no-repeat z-[-1]"
+        className="fixed top-0 left-0 w-full h-full bg-cover bg-center bg-no-repeat z-0"
         style={{
           backgroundImage: `url('/concept-bg.jpg')`
         }}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -17,7 +17,7 @@ const Layout: React.FC<LayoutProps> = ({ children, currentPage, onPageChange }) 
   ];
 
   return (
-    <div className="min-h-screen bg-dark-void">
+    <div className="min-h-screen">
       {/* Header */}
       <header className=" backdrop-blur-md sticky top-0 z-50">
         <div className=" mx-auto px-4 py-4">
@@ -39,12 +39,12 @@ const Layout: React.FC<LayoutProps> = ({ children, currentPage, onPageChange }) 
       </header>
 
       {/* Main Content */}
-      <main className="flex-1 pb-20">
+      <main className="flex-1 pb-20 relative z-10">
         {children}
       </main>
 
       {/* Bottom Navigation */}
-      <nav className="fixed bottom-0 left-0 right-0  backdrop-blur-md ">
+      <nav className="fixed bottom-0 left-0 right-0  backdrop-blur-md z-50">
         <div className="max-w-md mx-auto lg:max-w-4xl px-4">
           <div className="flex justify-around py-2">
             {navItems.map((item) => {


### PR DESCRIPTION
This commit fixes an issue where the fullscreen background image was not visible. The negative z-index was causing it to be hidden behind the default body background.

- Removed the negative z-index from the background image component.
- Adjusted the z-index of the main layout components (header, main content, and nav) to ensure they are layered correctly on top of the background.
- Removed the default background color from the main layout container to allow the background image to be visible.