### PR TITLE
Fix: Adjust mobile player layout to prevent footer overflow.

### DIFF
--- a/src/components/RadioPlayer.tsx
+++ b/src/components/RadioPlayer.tsx
@@ -21,7 +21,7 @@ const RadioPlayer: React.FC = () => {
   return (
     <>
       {/* Mobile Layout */}
-      <div className="lg:hidden flex flex-col h-full bg-gluon-grey/80 backdrop-blur-md border-none text-white rounded-2xl p-4">
+      <div className="lg:hidden flex flex-col h-full bg-gluon-grey/80 backdrop-blur-md border-none text-white rounded-2xl p-3">
         {/* Header */}
         <header className="flex items-center justify-between">
             <div className="flex items-center space-x-3">


### PR DESCRIPTION
- Reduces the padding on the mobile view of the RadioPlayer component from p-4 to p-3.
- This provides more vertical space within the fixed-height container, ensuring the footer is correctly displayed within the blurred glass effect area and is not visually cut off.
- This addresses a follow-up issue where the footer was not rendering correctly on mobile devices.