### PR TITLE
feat: update mobile player button style

### DIFF
--- a/src/components/RadioPlayer.tsx
+++ b/src/components/RadioPlayer.tsx
@@ -41,9 +41,9 @@ const RadioPlayer: React.FC = () => {
             <div className="h-full flex items-center justify-center">
                 <button
                     onClick={togglePlay}
-                    className="bg-gray-800 hover:bg-gray-700 text-white p-3 rounded-full transition-all duration-300 transform hover:scale-105 shadow-lg"
+                    className="bg-transparent hover:bg-transparent text-white p-6 rounded-full transition-all duration-300 transform hover:scale-105 shadow-lg border-2 border-white"
                 >
-                    {isPlaying ? <Pause size={24} fill="currentColor" /> : <Play size={24} fill="currentColor" />}
+                    {isPlaying ? <Pause size={48} fill="currentColor" /> : <Play size={48} fill="currentColor" />}
                 </button>
             </div>
 


### PR DESCRIPTION
This commit updates the style of the play button in the mobile version of the player.

The following changes have been made:
- Increased the size of the play button.
- Changed the background of the play button to transparent.
- Added a 2px solid white border to the play button.
- The play icon remains white.