### PR TITLE
feat: implement new mobile homepage layout

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -4,12 +4,12 @@ import NewRadioPlayer from './NewRadioPlayer';
 
 const HomePage: React.FC = () => {
   return (
-    <div className="h-[calc(100vh-8rem)] flex flex-col lg:flex-row gap-4 mx-auto px-4 lg:px-8">
-      {/* Left Sidebar - Hidden on mobile, visible on desktop */}
-      <div className="hidden lg:block lg:w-[25%] p-4">
-        <div className="h-[calc(100vh-12rem)] bg-white/10 backdrop-blur-xl rounded-3xl border border-white/20 shadow-2xl p-6">
+    <div className="grid h-screen grid-cols-2 grid-rows-[35%_auto] gap-4 px-4 mx-auto lg:flex lg:flex-row lg:h-[calc(100vh-8rem)] lg:px-8">
+      {/* Left Sidebar - Top-left on mobile, visible on all screens */}
+      <div className="col-start-1 row-start-1 p-4 lg:w-[25%]">
+        <div className="h-full p-6 bg-white/10 backdrop-blur-xl rounded-3xl border border-white/20 shadow-2xl lg:h-[calc(100vh-12rem)]">
           <div className="text-white">
-            <h3 className="text-lg font-semibold mb-4">Radio Info</h3>
+            <h3 className="mb-4 text-lg font-semibold">Radio Info</h3>
             <div className="space-y-3">
               <div className="text-sm opacity-80">
                 <p>Now Playing</p>
@@ -24,15 +24,15 @@ const HomePage: React.FC = () => {
         </div>
       </div>
 
-      {/* Hero Section - Slideshow Component - Mobile: full height, Desktop: 45% width */}
-      <div className="w-full h-full lg:w-[45%] p-4">
+      {/* Hero Section - Slideshow Component - Top-right on mobile */}
+      <div className="col-start-2 row-start-1 p-4 lg:w-[45%]">
         <div className="h-full lg:h-[calc(100vh-12rem)]">
           <HeroSection />
         </div>
       </div>
       
-      {/* Radio Player - Mobile: fixed bottom with 90px from navigation, Desktop: right side */}
-      <div className="fixed bottom-[110px] left-4 right-4 h-[160px] lg:relative lg:bottom-auto lg:left-auto lg:right-auto lg:w-[30%] lg:h-[calc(100vh-12rem)] z-10">
+      {/* Radio Player - Bottom on mobile, right side on desktop */}
+      <div className="col-span-2 row-start-2 lg:relative lg:bottom-auto lg:left-auto lg:right-auto lg:w-[30%] lg:h-[calc(100vh-12rem)]">
         <NewRadioPlayer />
       </div>
     </div>


### PR DESCRIPTION
- Replaced the flexbox layout with a CSS grid layout for mobile screens.
- The new layout consists of a 2x2 grid:
  - Top-left: Radio Info
  - Top-right: Hero Section (Slideshow)
  - Bottom: NewRadioPlayer, spanning both columns.
- The 'Radio Info' component is now visible on mobile.
- The 'NewRadioPlayer' is now part of the grid flow on mobile, instead of being fixed-positioned.
- The desktop layout remains unchanged.