### PR TITLE
feat: Refactor ConceptHomePage for separate mobile layout

### DIFF
--- a/src/components/ConceptHomePage.tsx
+++ b/src/components/ConceptHomePage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Users, Radio } from 'lucide-react';
 import RadioPlayer from './RadioPlayer';
 
+// Sub-component for the text content to avoid duplication
 const Content = () => (
   <div className="text-white">
     <h3 className="text-lg font-semibold mb-4">Radio Fenicottero</h3>
@@ -18,38 +18,57 @@ const Content = () => (
   </div>
 );
 
+// Sub-component for the blurred panel to avoid duplicating styles
+const BlurPanel: React.FC<{className?: string, children: React.ReactNode}> = ({ className, children }) => (
+    <div className={`bg-white/10 backdrop-blur-xl rounded-3xl border border-white/20 shadow-2xl p-6 ${className}`}>
+        {children}
+    </div>
+);
+
 
 const ConceptHomePage: React.FC = () => {
   return (
-    <div className="h-[calc(100vh-12rem)] flex flex-col lg:flex-row relative mx-auto px-4 lg:px-8">
-      {/* Full Background Image */}
+    <div className="h-[calc(100vh-12rem)] relative mx-auto px-4 lg:px-8">
+      {/* Full Background Image - Stays in the background for both layouts */}
       <div 
         className="fixed top-0 left-0 w-full h-full bg-cover bg-center bg-no-repeat bg-fixed z-0"
         style={{
           backgroundImage: `url('https://res.cloudinary.com/thinkdigital/image/upload/v1756910411/500501bc6a3eaca283c3c4951e15cc01_esu1fv.jpg')`
         }}
       >
-        {/* Dark overlay for better contrast */}
         <div className="absolute inset-0 bg-black/30"></div>
       </div>
 
-      {/* Content Section - DESKTOP */}
-      <div className="hidden lg:block lg:w-[65%] p-4">
-        <div className="h-[calc(100vh-12rem)] bg-white/10 backdrop-blur-xl rounded-3xl border border-white/20 shadow-2xl p-6">
-          <Content />
-        </div>
-      </div>
+      {/* --- Main Content Area --- */}
+      {/* We use a relative z-10 container to ensure content stays above the background */}
+      <div className="relative z-10 h-full">
 
-      {/* Content Section - MOBILE */}
-      <div className="lg:hidden absolute inset-0 p-4">
-        <div className="h-full bg-white/10 backdrop-blur-xl rounded-3xl border border-white/20 shadow-2xl p-6">
-          <Content />
+        {/* Desktop Layout */}
+        <div className="hidden lg:flex flex-row h-full space-x-4">
+          <div className="w-[65%] h-full">
+            <BlurPanel className="h-full">
+                <Content />
+            </BlurPanel>
+          </div>
+          <div className="w-[30%] h-full ml-auto">
+            <RadioPlayer />
+          </div>
         </div>
-      </div>
 
-      {/* Radio Player - Mobile: fixed bottom with 90px from navigation, Desktop: right side matching homepage */}
-      <div className="fixed bottom-[110px] left-4 right-4 h-[160px] lg:relative lg:bottom-auto lg:left-auto lg:right-auto lg:w-[30%] lg:h-[calc(100vh-12rem)] lg:ml-auto z-10">
-        <RadioPlayer />
+        {/* Mobile Layout */}
+        <div className="lg:hidden flex flex-col h-full">
+          {/* Content Panel fills the remaining space */}
+          <div className="flex-grow py-4">
+              <BlurPanel className="h-full">
+                  <Content />
+              </BlurPanel>
+          </div>
+          {/* Player has a fixed height at the bottom */}
+          <div className="h-[160px] pb-4">
+            <RadioPlayer />
+          </div>
+        </div>
+
       </div>
     </div>
   );


### PR DESCRIPTION
Refactors the component to use two distinct layouts for mobile and desktop, resolving issues with overlapping elements in the previous implementation.

- Extracts content and panel styling into reusable sub-components (`Content`, `BlurPanel`).
- Creates a new mobile-specific layout using flexbox (`flex-col`) to stack the content panel and the radio player vertically.
- The content panel uses `flex-grow` to fill the remaining space above the fixed-height radio player, as per the user's request.
- The desktop layout is preserved, using `flex-row`.