### PR TITLE
fix: resolve regression on mobile homepage layout

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -37,12 +37,12 @@ const HomePage: React.FC = () => {
   return (
     <>
       {/* Mobile Layout */}
-      <div className="lg:hidden flex flex-col h-full">
-        <div className="w-full flex-grow">
+      <div className="lg:hidden flex flex-col h-screen p-4 gap-4">
+        <div className="w-full h-[60%] rounded-lg overflow-hidden">
           <HeroSection slides={slides} onSlideChange={handleSlideChange} />
         </div>
         <DynamicTicker slide={currentSlide} />
-        <div className="p-4">
+        <div className="flex-grow">
           <NewRadioPlayer />
         </div>
       </div>


### PR DESCRIPTION
This commit fixes a regression introduced in the previous commit. The HeroSection was not visible on mobile and the rounded corners were missing.

- The mobile layout in `HomePage.tsx` has been adjusted to ensure the `HeroSection` has a visible height.
- The `rounded-lg` and `overflow-hidden` classes have been added to the `HeroSection` container to restore the rounded corners.