### PR TITLE
feat: Add pulse effect to active play button

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -40,3 +40,38 @@
 .read-the-docs {
   color: #888;
 }
+
+@keyframes pulse-animation {
+  0% {
+    transform: scale(1);
+    opacity: 0.5;
+  }
+  100% {
+    transform: scale(2.5);
+    opacity: 0;
+  }
+}
+
+.pulse-effect {
+  position: relative;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.pulse-effect::before,
+.pulse-effect::after {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  border: 2px solid white;
+  border-radius: 50%;
+  animation: pulse-animation 2s infinite;
+}
+
+.pulse-effect::after {
+  animation-delay: 1s;
+}

--- a/src/components/NewRadioPlayer.tsx
+++ b/src/components/NewRadioPlayer.tsx
@@ -39,12 +39,14 @@ const NewRadioPlayer: React.FC = () => {
 
             {/* Body (Play Button) */}
             <div className="h-full flex items-center justify-center">
-                <button
-                    onClick={togglePlay}
-                    className="bg-transparent hover:bg-transparent text-white p-4 rounded-full transition-all duration-300 transform hover:scale-105 shadow-lg border-2 border-white"
-                >
-                    {isPlaying ? <Pause size={36} fill="currentColor" /> : <Play size={36} fill="currentColor" />}
-                </button>
+                <div className={isPlaying ? 'pulse-effect' : ''}>
+                    <button
+                        onClick={togglePlay}
+                        className="bg-transparent hover:bg-transparent text-white p-4 rounded-full transition-all duration-300 transform hover:scale-105 shadow-lg border-2 border-white"
+                    >
+                        {isPlaying ? <Pause size={36} fill="currentColor" /> : <Play size={36} fill="currentColor" />}
+                    </button>
+                </div>
             </div>
 
             {/* Footer */}
@@ -76,12 +78,14 @@ const NewRadioPlayer: React.FC = () => {
 
         {/* Body (Play Button) */}
         <div className="flex-1 flex items-center justify-center">
-            <button
-                onClick={togglePlay}
-                className="bg-gray-800 hover:bg-gray-700 text-white p-4 rounded-full transition-all duration-300 transform hover:scale-105 shadow-lg"
-            >
-                {isPlaying ? <Pause size={28} fill="currentColor" /> : <Play size={28} fill="currentColor" />}
-            </button>
+            <div className={isPlaying ? 'pulse-effect' : ''}>
+                <button
+                    onClick={togglePlay}
+                    className="bg-gray-800 hover:bg-gray-700 text-white p-4 rounded-full transition-all duration-300 transform hover:scale-105 shadow-lg"
+                >
+                    {isPlaying ? <Pause size={28} fill="currentColor" /> : <Play size={28} fill="currentColor" />}
+                </button>
+            </div>
         </div>
 
         {/* Footer */}


### PR DESCRIPTION
This commit introduces a pulse animation for the play button when it is active. The effect consists of expanding and fading concentric circles, providing visual feedback that the radio is playing.

- Added `@keyframes` for the pulse animation in `src/App.css`.
- Created a `.pulse-effect` class to apply the animation.
- Modified `NewRadioPlayer.tsx` to conditionally apply the `pulse-effect` class to the play button's container when `isPlaying` is true for both mobile and desktop layouts.