### PR TITLE
fix: Allow clicks on play button when pulse effect is active

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -43,6 +43,7 @@
   border: 2px solid white;
   border-radius: 50%;
   animation: pulse-animation 2s infinite;
+  pointer-events: none;
 }
 
 .pulse-effect::after {


### PR DESCRIPTION
This commit fixes a regression where the play button was not clickable when the pulse effect was active. The pseudo-elements creating the animation were capturing mouse events.

The fix adds `pointer-events: none;` to the `::before` and `::after` pseudo-elements of the `.pulse-effect` class. This allows click events to pass through the animation to the button underneath, restoring its functionality.