### PR TITLE
feat: Add idle pulse effect to paused play button

### DIFF
--- a/src/components/NewRadioPlayer.tsx
+++ b/src/components/NewRadioPlayer.tsx
@@ -42,7 +42,7 @@ const NewRadioPlayer: React.FC = () => {
                 <div className={isPlaying ? 'pulse-effect' : ''}>
                     <button
                         onClick={togglePlay}
-                        className="bg-transparent hover:bg-transparent text-white p-4 rounded-full transition-all duration-300 transform hover:scale-105 shadow-lg border-2 border-white"
+                        className={`bg-transparent hover:bg-transparent text-white p-4 rounded-full transition-all duration-300 transform hover:scale-105 shadow-lg border-2 border-white ${!isPlaying ? 'idle-pulse' : ''}`}
                     >
                         {isPlaying ? <Pause size={36} fill="currentColor" /> : <Play size={36} fill="currentColor" />}
                     </button>
@@ -81,7 +81,7 @@ const NewRadioPlayer: React.FC = () => {
             <div className={isPlaying ? 'pulse-effect' : ''}>
                 <button
                     onClick={togglePlay}
-                    className="bg-gray-800 hover:bg-gray-700 text-white p-4 rounded-full transition-all duration-300 transform hover:scale-105 shadow-lg"
+                    className={`bg-gray-800 hover:bg-gray-700 text-white p-4 rounded-full transition-all duration-300 transform hover:scale-105 shadow-lg ${!isPlaying ? 'idle-pulse' : ''}`}
                 >
                     {isPlaying ? <Pause size={28} fill="currentColor" /> : <Play size={28} fill="currentColor" />}
                 </button>

--- a/src/components/RadioPlayer.tsx
+++ b/src/components/RadioPlayer.tsx
@@ -42,7 +42,7 @@ const RadioPlayer: React.FC = () => {
                 <div className={isPlaying ? 'pulse-effect' : ''}>
                     <button
                         onClick={togglePlay}
-                        className="bg-transparent hover:bg-transparent text-white p-4 rounded-full transition-all duration-300 transform hover:scale-105 shadow-lg border-2 border-white"
+                        className={`bg-transparent hover:bg-transparent text-white p-4 rounded-full transition-all duration-300 transform hover:scale-105 shadow-lg border-2 border-white ${!isPlaying ? 'idle-pulse' : ''}`}
                     >
                         {isPlaying ? <Pause size={36} fill="currentColor" /> : <Play size={36} fill="currentColor" />}
                     </button>
@@ -81,7 +81,7 @@ const RadioPlayer: React.FC = () => {
             <div className={isPlaying ? 'pulse-effect' : ''}>
                 <button
                     onClick={togglePlay}
-                    className="bg-gray-800 hover:bg-gray-700 text-white p-4 rounded-full transition-all duration-300 transform hover:scale-105 shadow-lg"
+                    className={`bg-gray-800 hover:bg-gray-700 text-white p-4 rounded-full transition-all duration-300 transform hover:scale-105 shadow-lg ${!isPlaying ? 'idle-pulse' : ''}`}
                 >
                     {isPlaying ? <Pause size={28} fill="currentColor" /> : <Play size={28} fill="currentColor" />}
                 </button>

--- a/src/index.css
+++ b/src/index.css
@@ -49,3 +49,16 @@
 .pulse-effect::after {
   animation-delay: 1s;
 }
+
+@keyframes idle-pulse {
+  0%, 100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
+}
+
+.idle-pulse {
+  animation: idle-pulse 3s infinite;
+}


### PR DESCRIPTION
This commit introduces a new pulse effect for the play button when it is in the paused state. This serves as a visual cue to encourage the user to start the radio.

The changes include:
- A new `@keyframes` animation called `idle-pulse` that subtly scales the button.
- A new `.idle-pulse` CSS class that applies this animation every 3 seconds.
- The `idle-pulse` class is conditionally applied to the play buttons in `NewRadioPlayer.tsx` and `RadioPlayer.tsx` when `isPlaying` is `false`.

This creates a different visual effect for the paused state compared to the playing state, as requested by the user.