### PR TITLE
feat: Add background gradients to playlist and podcast pages

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -17,8 +17,19 @@ const Layout: React.FC<LayoutProps> = ({ children, currentPage, onPageChange }) 
     { id: 'residents', label: 'Residents', icon: Users },
   ];
 
+  const getBackgroundClass = () => {
+    switch (currentPage) {
+      case 'playlists':
+        return 'bg-gradient-to-r from-red-500 to-pink-500';
+      case 'podcasts':
+        return 'bg-gradient-to-r from-pink-500 to-green-500';
+      default:
+        return '';
+    }
+  };
+
   return (
-    <div className="min-h-screen  flex flex-col">
+    <div className={`min-h-screen flex flex-col ${getBackgroundClass()}`}>
       {/* Header */}
       <header className=" backdrop-blur-md sticky top-0 z-50">
         <div className=" mx-auto px-4 py-4">


### PR DESCRIPTION
This commit introduces background gradients to the playlist and podcast pages as per the user's request.

- The playlist page now has a red-to-pink gradient background.
- The podcast page now has a pink-to-green gradient background.

The implementation was done in the `Layout.tsx` component to apply the styles conditionally based on the current page. This approach is more efficient and maintainable than styling each page component individually.