### PR TITLE
feat: Redesign PlaylistsPage to match reference image

### DIFF
--- a/src/components/PlaylistsPage.tsx
+++ b/src/components/PlaylistsPage.tsx
@@ -1,119 +1,101 @@
-import React from 'react';
-import { Play, Clock, Music } from 'lucide-react';
-import type { Playlist } from '../types';
+import React, { useState } from 'react';
+import { Heart, Headphones, MoreHorizontal, Play } from 'lucide-react';
+import { mockPlaylists } from '../data/playlists';
+import type { Track } from '../data/playlists';
+
+// Helper function to format large numbers into a 'k' format
+const formatListens = (count?: number): string => {
+  if (!count) return '0';
+  if (count >= 1000) {
+    return `${Math.round(count / 1000)}k`;
+  }
+  return count.toString();
+};
 
 const PlaylistsPage: React.FC = () => {
-  const playlists: Playlist[] = [
-    {
-      id: '1',
-      name: 'Deep House',
-      description: 'The best deep house tracks for your soul',
-      image: 'https://placehold.co/600x400',
-tracks: [
- { id: '1', title: 'Midnight City', artist: 'M83', duration: '4:03' },
-        { id: '2', title: 'Strobe', artist: 'Deadmau5', duration: '10:32' },
-        { id: '3', title: 'Teardrop', artist: 'Massive Attack', duration: '5:29' }
-      ]
-    },
-    {
-      id: '2',
-      name: 'Morning Energy',
-      description: 'Uplifting beats to start your day',
-      image: 'https://placehold.co/600x400',
-      tracks: [
-        { id: '4', title: 'One More Time', artist: 'Daft Punk', duration: '5:20' },
-        { id: '5', title: 'Levels', artist: 'Avicii', duration: '6:02' },
-        { id: '6', title: 'Titanium', artist: 'David Guetta ft. Sia', duration: '4:05' }
-      ]
-    },
-    {
-      id: '3',
-      name: 'Chill Vibes',
-      description: 'Relaxing sounds for peaceful moments',
-      image: 'https://placehold.co/600x400',
-      tracks: [
-        { id: '7', title: 'Weightless', artist: 'Marconi Union', duration: '8:08' },
-        { id: '8', title: 'Porcelain', artist: 'Moby', duration: '4:01' },
-        { id: '9', title: 'Kiara', artist: 'Bonobo', duration: '5:27' }
-      ]
-    }
-  ];
+  // We'll use the first playlist as our "Tracks of the Week"
+  const playlist = mockPlaylists[0];
 
-  const getTotalDuration = (tracks: any[]) => {
-    const totalSeconds = tracks.reduce((acc, track) => {
-      const [minutes, seconds] = track.duration.split(':').map(Number);
-      return acc + minutes * 60 + seconds;
-    }, 0);
-    const hours = Math.floor(totalSeconds / 3600);
-    const minutes = Math.floor((totalSeconds % 3600) / 60);
-    return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
-  };
+  // State to keep track of the currently active/playing track
+  const [activeTrackId, setActiveTrackId] = useState<string | null>('track4');
 
   return (
-    <div className="max-w-md mx-auto lg:max-w-4xl p-4 lg:p-8 space-y-6">
-      <div className="flex items-center space-x-2 mb-6">
-        <Music className="text-liquid-lava" size={24} />
-        <h2 className="text-snow font-bold text-2xl">Playlists</h2>
-      </div>
+    <div className="text-white p-4 sm:p-6 md:p-8 font-sans" style={{ backgroundColor: '#121212' }}>
+      <div className="max-w-4xl mx-auto">
+        {/* Header */}
+        <div className="flex justify-between items-center mb-6">
+          <h1 className="text-2xl font-bold">Tracks Of The Week</h1>
+          <a href="#" className="text-xs font-semibold tracking-widest text-gray-400 hover:text-white transition-colors">
+            SEE ALL
+          </a>
+        </div>
 
-      <div className="space-y-6">
-        {playlists.map((playlist) => (
-          <div
-            key={playlist.id}
-            className="bg-gluon-grey/80 backdrop-blur-md rounded-2xl border border-slate-grey/50 overflow-hidden"
-          >
-            {/* Playlist Header */}
-            <div className="relative h-48">
-              <img
-                src={playlist.image}
-                alt={playlist.name}
-                className="w-full h-full object-cover"
-              />
-              <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent" />
-              <div className="absolute bottom-4 left-4 right-4">
-                <h3 className="text-snow font-bold text-xl mb-1">{playlist.name}</h3>
-                <p className="text-dusty-grey text-sm mb-3">{playlist.description}</p>
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center space-x-4 text-dusty-grey text-sm">
-                    <span>{playlist.tracks.length} tracks</span>
-                    <span>•</span>
-                    <span>{getTotalDuration(playlist.tracks)}</span>
-                  </div>
-                  <button className="bg-liquid-lava hover:bg-liquid-lava/80 text-snow p-3 rounded-full transition-colors">
-                    <Play size={20} />
+        {/* Track List */}
+        <div className="space-y-1">
+          {playlist.tracks.map((track: Track) => {
+            const isActive = track.id === activeTrackId;
+            return (
+              <div
+                key={track.id}
+                className={`grid grid-cols-12 gap-4 items-center p-2 rounded-lg cursor-pointer transition-colors ${
+                  isActive ? 'bg-white/10' : 'hover:bg-white/5'
+                }`}
+                onClick={() => setActiveTrackId(track.id)}
+              >
+                {/* Album Art */}
+                <div className="col-span-1 relative flex items-center justify-center">
+                  <img
+                    src={track.imageUrl || 'https://placehold.co/100x100/121212/FFFFFF/png?text=404'}
+                    alt={track.title}
+                    className="w-10 h-10 rounded-md"
+                  />
+                  {isActive && (
+                    <div className="absolute inset-0 bg-black bg-opacity-60 flex items-center justify-center rounded-md">
+                      <Play className="text-white" size={20} />
+                    </div>
+                  )}
+                </div>
+
+                {/* Title & Artist */}
+                <div className="col-span-5">
+                  <p className={`font-medium truncate ${isActive ? 'text-green-400' : 'text-white'}`}>
+                    {track.title}
+                  </p>
+                </div>
+                <div className="col-span-2">
+                  <p className="text-gray-400 text-sm truncate">{track.artist}</p>
+                </div>
+
+                {/* Duration */}
+                <div className="col-span-1 text-gray-400 text-sm text-right">
+                  {track.duration}
+                </div>
+
+                {/* Likes */}
+                <div className="col-span-1 flex justify-center">
+                  <button className="text-gray-400 hover:text-white transition-colors">
+                    <Heart size={18} />
                   </button>
                 </div>
-              </div>
-            </div>
 
-            {/* Track List */}
-            <div className="p-4">
-              <div className="space-y-2">
-                {playlist.tracks.map((track, index) => (
-                  <div
-                    key={track.id}
-                    className="flex items-center space-x-3 p-3 rounded-lg hover:bg-slate-grey/30 transition-colors group"
-                  >
-                    <span className="text-dusty-grey text-sm w-6 text-center group-hover:hidden">
-                      {index + 1}
-                    </span>
-                    <button className="text-liquid-lava hidden group-hover:block">
-                      <Play size={16} />
+                {/* Listens */}
+                <div className="col-span-1 flex items-center text-gray-400 text-sm">
+                  <Headphones size={18} className="mr-1" />
+                  <span>{formatListens(track.listenCount)}</span>
+                </div>
+
+                {/* More Options */}
+                <div className="col-span-1 flex justify-end">
+                  {isActive && (
+                    <button className="text-gray-400 hover:text-white transition-colors">
+                      <MoreHorizontal size={20} />
                     </button>
-                    <div className="flex-1 min-w-0">
-                      <p className="text-snow font-medium truncate">{track.title}</p>
-                      <p className="text-dusty-grey text-sm truncate">{track.artist}</p>
-                    </div>
-                    <div className="flex items-center space-x-2 text-dusty-grey text-sm">
-                      <Clock size={14} />
-                      <span>{track.duration}</span>
-                    </div>
-                  </div>
-                ))}
+                  )}
+                </div>
               </div>
-            </div>
-          </div>
-        ))}
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/data/playlists.ts
+++ b/src/data/playlists.ts
@@ -3,8 +3,9 @@ export interface Track {
   title: string;
   artist: string;
   audioUrl: string;
-  imageUrl?: string; // Optional album/track art
-  duration?: string; // Optional, e.g., "3:45"
+  imageUrl?: string;
+  duration?: string;
+  listenCount?: number;
 }
 
 export interface Playlist {
@@ -24,35 +25,39 @@ export const mockPlaylists: Playlist[] = [
     tracks: [
       {
         id: "track1",
-        title: "Sunset Drive",
-        artist: "Synthwave Explorer",
+        title: "Stay Forever",
+        artist: "Poets of the Fall",
         audioUrl: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-1.mp3",
-        imageUrl: "https://placehold.co/100x100/FF6347/FFFFFF/png?text=Sunset",
-        duration: "3:30",
+        imageUrl: "https://i.scdn.co/image/ab67616d00004851f53434b3e035a4a5dc5127f8",
+        duration: "3:43",
+        listenCount: 198000,
       },
       {
         id: "track2",
-        title: "Morning Coffee",
-        artist: "Chill Beats Collective",
+        title: "Turn Around",
+        artist: "Early Winters",
         audioUrl: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-2.mp3",
-        imageUrl: "https://placehold.co/100x100/4682B4/FFFFFF/png?text=Coffee",
-        duration: "2:45",
+        imageUrl: "https://i.scdn.co/image/ab67616d00004851c9a3c396c4597b415174f475",
+        duration: "4:04",
+        listenCount: 122000,
       },
       {
         id: "track3",
-        title: "Neon Nights",
-        artist: "Retro Future",
+        title: "Colour Me In",
+        artist: "Damien Rice",
         audioUrl: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-3.mp3",
-        imageUrl: "https://placehold.co/100x100/8A2BE2/FFFFFF/png?text=Neon",
-        duration: "4:15",
+        imageUrl: "https://i.scdn.co/image/ab67616d00004851ff13136206c6ad10597371f6",
+        duration: "5:18",
+        listenCount: 98000,
       },
       {
         id: "track4",
-        title: "Ocean Breeze",
-        artist: "Island Grooves",
+        title: "Hypnotic",
+        artist: "Zella Day",
         audioUrl: "https://www.soundhelix.com/examples/mp3/SoundHelix-Song-4.mp3",
-        // No imageUrl for this track to test fallback
-        duration: "3:50",
+        imageUrl: "https://i.scdn.co/image/ab67616d000048511392e2815f376f989d532822",
+        duration: "3:34",
+        listenCount: 94000,
       },
     ],
   },


### PR DESCRIPTION
This commit completely redesigns the `PlaylistsPage` component to align with the user's provided reference image.

The key changes include:
- Overhauling the layout of `PlaylistsPage.tsx` to display a single 'Tracks of the Week' list instead of multiple playlists.
- The new track list item design is implemented using Tailwind CSS Grid and includes album art, title, artist, duration, likes, and listen count.
- Added a `useState` hook to manage the active track, which is visually highlighted and displays interactive elements, matching the reference image.
- Updated the mock data in `src/data/playlists.ts` to include `listenCount` and more realistic track information derived from the image.
- Included a helper function to format large listen counts into a more readable 'k' format (e.g., 198k).