### PR TITLE
feat: Transform content into a mobile ticker

### DIFF
--- a/src/components/ConceptHomePage.tsx
+++ b/src/components/ConceptHomePage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { Users, Radio } from 'lucide-react';
 import RadioPlayer from './RadioPlayer';
+import MobileTicker from './mobile/MobileTicker';
 
 const images = [
   'https://res.cloudinary.com/thinkdigital/image/upload/c_pad,b_gen_fill,ar_16:9/v1758625184/radio%20amble%20immagini/gemini-2.5-flash-image-preview_nano-banana__Steeve_Macqueen_che_.png',
@@ -10,22 +10,20 @@ const images = [
   'https://res.cloudinary.com/thinkdigital/image/upload/v1758716754/1758715806855-177b2083-d42a-4ea7-951c-bfcdc1838437_ejvwya.png'
 ];
 
-const Content = () => (
-  <div className="text-white">
-    <h3 className="text-lg font-semibold mb-4">Radio Fenicottero</h3>
-    <div className="space-y-3">
-      <div className="text-2xl lg:text-4xl opacity-80">
-        <p>Benvenuti su Radio Amblè</p>
-        <p className="text-xl lg:text-2xl">Fresh Sound and Podcasts</p>
-      </div>
-      <div className="text-2xl lg:text-4xl opacity-80">
-        <p>In onda ora</p>
-        <p className="text-xl lg:text-2xl">Musica Live 24/7</p>
-      </div>
-    </div>
-  </div>
-);
+const desktopContent = {
+  title: 'Radio Fenicottero',
+  welcome: 'Benvenuti su Radio Amblè',
+  welcomeSubtitle: 'Fresh Sound and Podcasts',
+  nowPlaying: 'In onda ora',
+  nowPlayingSubtitle: 'Musica Live 24/7'
+};
 
+const mobileContent = {
+  title: 'Benvenuti su Radio Amblè',
+  subtitle: 'Fresh Sound and Podcasts',
+  show: 'In onda ora',
+  showSubtitle: 'Musica Live 24/7'
+};
 
 const ConceptHomePage: React.FC = () => {
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
@@ -61,15 +59,25 @@ const ConceptHomePage: React.FC = () => {
 
       {/* Content Section - DESKTOP */}
       <div className="hidden lg:block lg:w-[65%] p-4">
-        <div className="h-[calc(100vh-12rem)]">
-          <Content />
+        <div className="h-[calc(100vh-12rem)] text-white">
+          <h3 className="text-lg font-semibold mb-4">{desktopContent.title}</h3>
+          <div className="space-y-3">
+            <div className="text-2xl lg:text-4xl opacity-80">
+              <p>{desktopContent.welcome}</p>
+              <p className="text-xl lg:text-2xl">{desktopContent.welcomeSubtitle}</p>
+            </div>
+            <div className="text-2xl lg:text-4xl opacity-80">
+              <p>{desktopContent.nowPlaying}</p>
+              <p className="text-xl lg:text-2xl">{desktopContent.nowPlayingSubtitle}</p>
+            </div>
+          </div>
         </div>
       </div>
 
       {/* Content Section - MOBILE */}
       <div className="lg:hidden absolute top-4 left-4 right-4 bottom-[220px] p-2">
         <div className="h-full p-6">
-          <Content />
+          <MobileTicker content={mobileContent} />
         </div>
       </div>
 

--- a/src/components/Videobg.tsx
+++ b/src/components/Videobg.tsx
@@ -1,23 +1,21 @@
 import React from 'react';
-import { Users, Radio } from 'lucide-react';
 import RadioPlayer from './RadioPlayer';
+import MobileTicker from './mobile/MobileTicker';
 
-const Content = () => (
-  <div className="text-white">
-    <h3 className="text-lg font-semibold mb-4">Radio Fenicottero</h3>
-    <div className="space-y-3">
-      <div className="text-2xl lg:text-4xl opacity-80">
-        <p>Benvenuti su Radio Amble</p>
-        <p className="text-xl lg:text-2xl">Fresh Sound and Podcasts</p>
-      </div>
-      <div className="text-2xl lg:text-4xl opacity-80">
-        <p>In onda ora</p>
-        <p className="text-xl lg:text-2xl">Musica Live 24/7</p>
-      </div>
-    </div>
-  </div>
-);
+const desktopContent = {
+  title: 'Radio Fenicottero',
+  welcome: 'Benvenuti su Radio Amble',
+  welcomeSubtitle: 'Fresh Sound and Podcasts',
+  nowPlaying: 'In onda ora',
+  nowPlayingSubtitle: 'Musica Live 24/7'
+};
 
+const mobileContent = {
+  title: 'Benvenuti su Radio Amble',
+  subtitle: 'Fresh Sound and Podcasts',
+  show: 'In onda ora',
+  showSubtitle: 'Musica Live 24/7'
+};
 
 const Videobg: React.FC = () => {
   return (
@@ -36,15 +34,25 @@ const Videobg: React.FC = () => {
         <div className="absolute inset-0"></div>
       {/* Content Section - DESKTOP */}
       <div className="hidden lg:block lg:w-[65%] p-4">
-        <div className="h-[calc(100vh-12rem)]  p-6">
-          <Content />
+        <div className="h-[calc(100vh-12rem)]  p-6 text-white">
+          <h3 className="text-lg font-semibold mb-4">{desktopContent.title}</h3>
+          <div className="space-y-3">
+            <div className="text-2xl lg:text-4xl opacity-80">
+              <p>{desktopContent.welcome}</p>
+              <p className="text-xl lg:text-2xl">{desktopContent.welcomeSubtitle}</p>
+            </div>
+            <div className="text-2xl lg:text-4xl opacity-80">
+              <p>{desktopContent.nowPlaying}</p>
+              <p className="text-xl lg:text-2xl">{desktopContent.nowPlayingSubtitle}</p>
+            </div>
+          </div>
         </div>
       </div>
 
       {/* Content Section - MOBILE */}
       <div className="lg:hidden absolute top-4 left-4 right-4 bottom-[220px] p-2">
         <div className="h-full">
-          <Content />
+          <MobileTicker content={mobileContent} />
         </div>
       </div>
 

--- a/src/components/mobile/MobileTicker.tsx
+++ b/src/components/mobile/MobileTicker.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface MobileTickerProps {
+  content: {
+    title: string;
+    subtitle: string;
+    show: string;
+    showSubtitle: string;
+  };
+}
+
+const MobileTicker: React.FC<MobileTickerProps> = ({ content }) => {
+  return (
+    <div className="text-white overflow-hidden w-full">
+      <div className="animate-marquee whitespace-nowrap">
+        <span className="mx-4 font-bold">{content.title}</span>
+        <span className="mx-4">{content.subtitle}</span>
+        <span className="mx-4 font-bold">{content.show}</span>
+        <span className="mx-4">{content.showSubtitle}</span>
+      </div>
+    </div>
+  );
+};
+
+export default MobileTicker;

--- a/src/index.css
+++ b/src/index.css
@@ -66,3 +66,16 @@ html, body, #root {
 .idle-pulse {
   animation: idle-pulse 3s infinite;
 }
+
+@keyframes marquee {
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(-100%);
+  }
+}
+
+.animate-marquee {
+  animation: marquee 15s linear infinite;
+}


### PR DESCRIPTION
This commit transforms the static content component into a scrolling ticker for the mobile versions of the `ConceptHomePage` and `Videobg` pages.

- A new `MobileTicker` component has been created to display scrolling text, ensuring a consistent look and feel with the `HomePage`'s mobile version.
- The `ConceptHomePage` and `Videobg` components now use the `MobileTicker` in their mobile views.
- The necessary CSS for the marquee animation has been added to `index.css`.