### PR TITLE
refactor: Reposition mobile ticker

### DIFF
--- a/src/components/ConceptHomePage.tsx
+++ b/src/components/ConceptHomePage.tsx
@@ -77,8 +77,13 @@ const ConceptHomePage: React.FC = () => {
       {/* Content Section - MOBILE */}
       <div className="lg:hidden absolute top-4 left-4 right-4 bottom-[220px] p-2">
         <div className="h-full p-6">
-          <MobileTicker content={mobileContent} />
+          {/* Ticker has been moved to be above the player */}
         </div>
+      </div>
+
+      {/* Mobile Ticker */}
+      <div className="lg:hidden fixed bottom-[275px] left-0 right-0 z-10 px-4">
+        <MobileTicker content={mobileContent} />
       </div>
 
       {/* Radio Player - Mobile: fixed bottom with margin, Desktop: right side matching homepage */}

--- a/src/components/Videobg.tsx
+++ b/src/components/Videobg.tsx
@@ -52,8 +52,13 @@ const Videobg: React.FC = () => {
       {/* Content Section - MOBILE */}
       <div className="lg:hidden absolute top-4 left-4 right-4 bottom-[220px] p-2">
         <div className="h-full">
-          <MobileTicker content={mobileContent} />
+          {/* Ticker has been moved to be above the player */}
         </div>
+      </div>
+
+      {/* Mobile Ticker */}
+      <div className="lg:hidden fixed bottom-[275px] left-0 right-0 z-10 px-4">
+        <MobileTicker content={mobileContent} />
       </div>
 
       {/* Radio Player - Mobile: fixed bottom with margin, Desktop: right side matching homepage */}


### PR DESCRIPTION
This commit repositions the `MobileTicker` component to be just above the `RadioPlayer` component in the mobile versions of the `ConceptHomePage` and `Videobg` pages.

This change was made to address a follow-up request from the user.