### PR TITLE
feat: Add admin page to control homepage content

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,8 @@ import Videobg from './components/Videobg';
 import PlaylistsPage from './components/PlaylistsPage';
 import PodcastsPage from './components/PodcastsPage';
 import ResidentsPage from './components/ResidentsPage';
+import AdminPage from './components/AdminPage';
+import { UIProvider } from './contexts/UIContext';
 
 function App() {
   const [currentPage, setCurrentPage] = useState('home');
@@ -24,15 +26,19 @@ function App() {
         return <PodcastsPage />;
       case 'residents':
         return <ResidentsPage />;
+      case 'admin':
+        return <AdminPage />;
       default:
         return <ConceptHomePage />;
     }
   };
 
   return (
-    <Layout currentPage={currentPage} onPageChange={setCurrentPage}>
-      {renderPage()}
-    </Layout>
+    <UIProvider>
+      <Layout currentPage={currentPage} onPageChange={setCurrentPage}>
+        {renderPage()}
+      </Layout>
+    </UIProvider>
   );
 }
 

--- a/src/components/AdminPage.tsx
+++ b/src/components/AdminPage.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useUIState, useUIActions } from '../contexts/UIContext';
+
+const AdminPage: React.FC = () => {
+  const { showVideo } = useUIState();
+  const { toggleShowVideo } = useUIActions();
+
+  return (
+    <div className="p-8 text-white">
+      <h1 className="text-3xl font-bold mb-6">Admin Panel</h1>
+      <div className="bg-gray-800 p-6 rounded-lg">
+        <h2 className="text-xl font-semibold mb-4">Homepage Settings</h2>
+        <div className="flex items-center justify-between">
+          <p>Toggle between Slideshow and Video Background</p>
+          <button
+            onClick={toggleShowVideo}
+            className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md transition-colors"
+          >
+            {showVideo ? 'Show Slideshow' : 'Show Video'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default AdminPage;

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -3,6 +3,7 @@ import HeroSection, { HeroSlide } from './HeroSection';
 import NewRadioPlayer from './NewRadioPlayer';
 import DynamicTicker from './DynamicTicker';
 import VideoBackground from './VideoBackground';
+import { useUIState } from '../contexts/UIContext';
 
 const slides: HeroSlide[] = [
   {
@@ -30,7 +31,7 @@ const slides: HeroSlide[] = [
 
 const HomePage: React.FC = () => {
   const [currentSlide, setCurrentSlide] = useState<HeroSlide | null>(null);
-  const [showVideo, setShowVideo] = useState(false);
+  const { showVideo } = useUIState();
 
   const handleSlideChange = (slide: HeroSlide) => {
     setCurrentSlide(slide);
@@ -40,16 +41,6 @@ const HomePage: React.FC = () => {
 
   return (
     <>
-      {/* Toggle Button */}
-      <div className="absolute top-20 right-4 z-20">
-        <button
-          onClick={() => setShowVideo(!showVideo)}
-          className="px-4 py-2 bg-gray-800 text-white rounded"
-        >
-          {showVideo ? 'Show Slideshow' : 'Show Video'}
-        </button>
-      </div>
-
       {/* Mobile Layout */}
       <div className="lg:hidden flex flex-col h-[calc(100vh-12rem)] p-4 gap-4 bg-[#151419] relative">
         <div className="w-full h-[50%] rounded-lg overflow-hidden rounded-3xl shadow-2xl bg-[#151419]">

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -15,6 +15,7 @@ const Layout: React.FC<LayoutProps> = ({ children, currentPage, onPageChange }) 
     { id: 'playlists', label: 'Playlist', icon: Music },
     { id: 'podcasts', label: 'Podcast', icon: Mic },
     { id: 'residents', label: 'Residents', icon: Users },
+    { id: 'admin', label: 'Admin', icon: Grid3X3 },
   ];
 
   const getBackgroundClass = () => {

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -1,0 +1,55 @@
+import React, { createContext, useState, useContext, ReactNode } from 'react';
+
+// 1. Define the shape of the state and actions
+interface UIState {
+  showVideo: boolean;
+}
+
+interface UIActions {
+  toggleShowVideo: () => void;
+}
+
+// 2. Create contexts
+const UIStateContext = createContext<UIState | undefined>(undefined);
+const UIActionsContext = createContext<UIActions | undefined>(undefined);
+
+// 3. Create the provider component
+interface UIProviderProps {
+  children: ReactNode;
+}
+
+export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
+  const [showVideo, setShowVideo] = useState(false);
+
+  const toggleShowVideo = () => {
+    setShowVideo(prev => !prev);
+  };
+
+  const state: UIState = { showVideo };
+  const actions: UIActions = { toggleShowVideo };
+
+  return (
+    <UIStateContext.Provider value={state}>
+      <UIActionsContext.Provider value={actions}>
+        {children}
+      </UIActionsContext.Provider>
+    </UIStateContext.Provider>
+  );
+};
+
+// 4. Create custom hooks for easy access
+export const useUIState = (): UIState => {
+  const context = useContext(UIStateContext);
+  if (context === undefined) {
+    throw new Error('useUIState must be used within a UIProvider');
+  }
+  return context;
+};
+
+export const useUIActions = (): UIActions => {
+  const context = useContext(UIActionsContext);
+  if (context === undefined) {
+    throw new Error('useUIActions must be used within a UIProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
- Creates a `UIContext` to manage shared UI state globally.
- Adds a new `AdminPage` component with a toggle to control whether the homepage displays a video background or a slideshow.
- Refactors `HomePage` to use the shared `UIContext` for deciding which component to render.
- Adds a link to the `AdminPage` in the main navigation.
- This centralizes content management and allows for future extensions to the admin panel.