### PR TITLE
feat: Make admin page accessible via specific URL

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import Layout from './components/Layout';
 import HomePage from './components/HomePage';
 import ConceptHomePage from './components/ConceptHomePage';
@@ -11,6 +11,13 @@ import { UIProvider } from './contexts/UIContext';
 
 function App() {
   const [currentPage, setCurrentPage] = useState('home');
+
+  useEffect(() => {
+    const path = window.location.pathname;
+    if (path === '/admin') {
+      setCurrentPage('admin');
+    }
+  }, []);
 
   const renderPage = () => {
     switch (currentPage) {

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -15,7 +15,6 @@ const Layout: React.FC<LayoutProps> = ({ children, currentPage, onPageChange }) 
     { id: 'playlists', label: 'Playlist', icon: Music },
     { id: 'podcasts', label: 'Podcast', icon: Mic },
     { id: 'residents', label: 'Residents', icon: Users },
-    { id: 'admin', label: 'Admin', icon: Grid3X3 },
   ];
 
   const getBackgroundClass = () => {


### PR DESCRIPTION
- Removes the 'Admin' link from the main navigation in `Layout.tsx`.
- Implements URL-based routing in `App.tsx` to display the `AdminPage` when the browser path is '/admin'.
- This makes the admin page accessible only to those who know the direct URL, effectively hiding it from the main user interface.