### PR TITLE
feat: Add content management to admin page

### DIFF
--- a/src/components/AdminPage.tsx
+++ b/src/components/AdminPage.tsx
@@ -1,22 +1,81 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useUIState, useUIActions } from '../contexts/UIContext';
+import { HeroSlide } from './HeroSection';
 
 const AdminPage: React.FC = () => {
-  const { showVideo } = useUIState();
-  const { toggleShowVideo } = useUIActions();
+  const { showVideo, videoSrc, slides } = useUIState();
+  const { toggleShowVideo, setVideoSrc, setSlides } = useUIActions();
+
+  const [localVideoSrc, setLocalVideoSrc] = useState(videoSrc);
+  const [localSlidesJson, setLocalSlidesJson] = useState(JSON.stringify(slides, null, 2));
+
+  const handleVideoSave = () => {
+    setVideoSrc(localVideoSrc);
+    alert('Video URL saved!');
+  };
+
+  const handleSlidesSave = () => {
+    try {
+      const parsedSlides: HeroSlide[] = JSON.parse(localSlidesJson);
+      setSlides(parsedSlides);
+      alert('Slides data saved!');
+    } catch (error) {
+      alert('Error: Invalid JSON format for slides.');
+    }
+  };
 
   return (
     <div className="p-8 text-white">
       <h1 className="text-3xl font-bold mb-6">Admin Panel</h1>
-      <div className="bg-gray-800 p-6 rounded-lg">
-        <h2 className="text-xl font-semibold mb-4">Homepage Settings</h2>
+
+      <div className="bg-gray-800 p-6 rounded-lg mb-6">
+        <h2 className="text-xl font-semibold mb-4">Homepage Display Mode</h2>
         <div className="flex items-center justify-between">
-          <p>Toggle between Slideshow and Video Background</p>
+          <p>Current Mode: {showVideo ? 'Video Background' : 'Slideshow'}</p>
           <button
             onClick={toggleShowVideo}
             className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md transition-colors"
           >
-            {showVideo ? 'Show Slideshow' : 'Show Video'}
+            Switch to {showVideo ? 'Slideshow' : 'Video'}
+          </button>
+        </div>
+      </div>
+
+      <div className="bg-gray-800 p-6 rounded-lg mb-6">
+        <h2 className="text-xl font-semibold mb-4">Manage Video Background</h2>
+        <div className="flex flex-col space-y-2">
+          <label htmlFor="video-url">Video URL</label>
+          <input
+            id="video-url"
+            type="text"
+            value={localVideoSrc}
+            onChange={(e) => setLocalVideoSrc(e.target.value)}
+            className="p-2 rounded bg-gray-700 border border-gray-600"
+          />
+          <button
+            onClick={handleVideoSave}
+            className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-md transition-colors self-start"
+          >
+            Save Video URL
+          </button>
+        </div>
+      </div>
+
+      <div className="bg-gray-800 p-6 rounded-lg">
+        <h2 className="text-xl font-semibold mb-4">Manage Slideshow Content (JSON)</h2>
+        <div className="flex flex-col space-y-2">
+          <label htmlFor="slides-json">Slides Data</label>
+          <textarea
+            id="slides-json"
+            value={localSlidesJson}
+            onChange={(e) => setLocalSlidesJson(e.target.value)}
+            className="p-2 rounded bg-gray-700 border border-gray-600 h-64 font-mono"
+          />
+          <button
+            onClick={handleSlidesSave}
+            className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-md transition-colors self-start"
+          >
+            Save Slides Data
           </button>
         </div>
       </div>

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -5,39 +5,13 @@ import DynamicTicker from './DynamicTicker';
 import VideoBackground from './VideoBackground';
 import { useUIState } from '../contexts/UIContext';
 
-const slides: HeroSlide[] = [
-  {
-    id: '1',
-    title: 'Live Now: Morning Vibes',
-    subtitle: 'Fresh beats to start your day right',
-    image: 'https://res.cloudinary.com/thinkdigital/image/upload/v1758625050/radio%20amble%20immagini/gemini-2.5-flash-image-preview_nano-banana__Uomo_deve_tenere_in_.png',
-    type: 'show'
-  },
-  {
-    id: '2',
-    title: 'New Podcast Episode',
-    subtitle: 'Deep dive into electronic music culture',
-    image: 'https://res.cloudinary.com/thinkdigital/image/upload/v1758625066/radio%20amble%20immagini/Generated_Image_September_23_2025_-_11_38AM.png',
-    type: 'news'
-  },
-  {
-    id: '3',
-    title: 'Weekend Special',
-    subtitle: 'Non-stop mix sessions all weekend',
-    image: 'https://res.cloudinary.com/thinkdigital/image/upload/v1758625015/radio%20amble%20immagini/Generated_Image_September_23_2025_-_11_36AM.png',
-    type: 'event'
-  }
-];
-
 const HomePage: React.FC = () => {
   const [currentSlide, setCurrentSlide] = useState<HeroSlide | null>(null);
-  const { showVideo } = useUIState();
+  const { showVideo, videoSrc, slides } = useUIState();
 
   const handleSlideChange = (slide: HeroSlide) => {
     setCurrentSlide(slide);
   };
-
-  const videoSrc = "https://res.cloudinary.com/thinkdigital/video/upload/v1751534019/videoplayback_rm5v5m.mp4";
 
   return (
     <>

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -1,12 +1,44 @@
 import React, { createContext, useState, useContext, ReactNode } from 'react';
+import { HeroSlide } from '../components/HeroSection';
+
+// Initial Data
+const initialSlides: HeroSlide[] = [
+  {
+    id: '1',
+    title: 'Live Now: Morning Vibes',
+    subtitle: 'Fresh beats to start your day right',
+    image: 'https://res.cloudinary.com/thinkdigital/image/upload/v1758625050/radio%20amble%20immagini/gemini-2.5-flash-image-preview_nano-banana__Uomo_deve_tenere_in_.png',
+    type: 'show'
+  },
+  {
+    id: '2',
+    title: 'New Podcast Episode',
+    subtitle: 'Deep dive into electronic music culture',
+    image: 'https://res.cloudinary.com/thinkdigital/image/upload/v1758625066/radio%20amble%20immagini/Generated_Image_September_23_2025_-_11_38AM.png',
+    type: 'news'
+  },
+  {
+    id: '3',
+    title: 'Weekend Special',
+    subtitle: 'Non-stop mix sessions all weekend',
+    image: 'https://res.cloudinary.com/thinkdigital/image/upload/v1758625015/radio%20amble%20immagini/Generated_Image_September_23_2025_-_11_36AM.png',
+    type: 'event'
+  }
+];
+
+const initialVideoSrc = "https://res.cloudinary.com/thinkdigital/video/upload/v1751534019/videoplayback_rm5v5m.mp4";
 
 // 1. Define the shape of the state and actions
 interface UIState {
   showVideo: boolean;
+  videoSrc: string;
+  slides: HeroSlide[];
 }
 
 interface UIActions {
   toggleShowVideo: () => void;
+  setVideoSrc: (url: string) => void;
+  setSlides: (slides: HeroSlide[]) => void;
 }
 
 // 2. Create contexts
@@ -20,13 +52,19 @@ interface UIProviderProps {
 
 export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
   const [showVideo, setShowVideo] = useState(false);
+  const [videoSrc, setVideoSrc] = useState(initialVideoSrc);
+  const [slides, setSlides] = useState<HeroSlide[]>(initialSlides);
 
   const toggleShowVideo = () => {
     setShowVideo(prev => !prev);
   };
 
-  const state: UIState = { showVideo };
-  const actions: UIActions = { toggleShowVideo };
+  const state: UIState = { showVideo, videoSrc, slides };
+  const actions: UIActions = {
+    toggleShowVideo,
+    setVideoSrc,
+    setSlides,
+  };
 
   return (
     <UIStateContext.Provider value={state}>


### PR DESCRIPTION
- Extends the `UIContext` to manage the video URL and slideshow data.
- Updates the `AdminPage` to include forms for editing the video URL and the slideshow content (as JSON).
- Refactors the `HomePage` to consume the content from the `UIContext`, removing hardcoded data.
- This allows for dynamic content management of the homepage directly from the admin panel.