### PR TITLE
fix: Add loading indicator to homepage

### DIFF
--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -7,11 +7,15 @@ import { useUIState } from '../contexts/UIContext';
 
 const HomePage: React.FC = () => {
   const [currentSlide, setCurrentSlide] = useState<HeroSlide | null>(null);
-  const { showVideo, videoSrc, slides } = useUIState();
+  const { showVideo, videoSrc, slides, isLoading } = useUIState();
 
   const handleSlideChange = (slide: HeroSlide) => {
     setCurrentSlide(slide);
   };
+
+  if (isLoading) {
+    return <div className="p-8 text-white">Loading...</div>;
+  }
 
   return (
     <>


### PR DESCRIPTION
- Modifies the `HomePage` component to use the `isLoading` state from the `UIContext`.
- Displays a "Loading..." message while the initial settings are being fetched from the backend.
- This resolves an issue where the slideshow or video would not be visible on the initial load because the data was not yet available.