### PR TITLE
Feat: Add main text management to admin panel

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,1 @@
-
 VITE_API_BASE_URL=https://radio-amble-backend.onrender.com
-
-VITE_API_BASE_URL=https://radio-amble-backend.onrender.com
-

--- a/backend/db.json
+++ b/backend/db.json
@@ -23,5 +23,6 @@
       "image": "https://res.cloudinary.com/thinkdigital/image/upload/v1758625015/radio%20amble%20immagini/Generated_Image_September_23_2025_-_11_36AM.png",
       "type": "event"
     }
-  ]
+  ],
+  "mainText": "This is the default text for the sidebar and content areas."
 }

--- a/src/components/AdminPage.tsx
+++ b/src/components/AdminPage.tsx
@@ -3,19 +3,20 @@ import { useUIState, useUIActions } from '../contexts/UIContext';
 import { HeroSlide } from './HeroSection';
 
 const AdminPage: React.FC = () => {
-  const { showVideo, videoSrc, slides, isLoading, error } = useUIState();
-  const { toggleShowVideo, setVideoSrc, setSlides } = useUIActions();
+  const { showVideo, videoSrc, slides, mainText, isLoading, error } = useUIState();
+  const { toggleShowVideo, setVideoSrc, setSlides, setMainText } = useUIActions();
 
   const [localVideoSrc, setLocalVideoSrc] = useState(videoSrc);
   const [localSlides, setLocalSlides] = useState<HeroSlide[]>(slides);
+  const [localMainText, setLocalMainText] = useState(mainText);
 
   useEffect(() => {
     setLocalVideoSrc(videoSrc);
     setLocalSlides(slides);
-  }, [videoSrc, slides]);
+    setLocalMainText(mainText);
+  }, [videoSrc, slides, mainText]);
 
-  const handleVideoSave = async () => {
-    const newSettings = { showVideo, slides, videoSrc: localVideoSrc };
+  const handleSaveSettings = async (newSettings: any) => {
     const apiUrl = `${import.meta.env.VITE_API_BASE_URL}/api/settings`;
     try {
       const response = await fetch(apiUrl, {
@@ -24,11 +25,35 @@ const AdminPage: React.FC = () => {
         body: JSON.stringify(newSettings),
       });
       if (!response.ok) throw new Error('Failed to save settings.');
-      setVideoSrc(localVideoSrc);
-      alert('Video URL saved!');
+      return true;
     } catch (error) {
       console.error(error);
-      alert('Error saving video URL.');
+      alert('Error saving settings.');
+      return false;
+    }
+  };
+
+  const handleVideoSave = async () => {
+    const success = await handleSaveSettings({ showVideo, slides, mainText, videoSrc: localVideoSrc });
+    if (success) {
+      setVideoSrc(localVideoSrc);
+      alert('Video URL saved!');
+    }
+  };
+
+  const handleSlidesSave = async () => {
+    const success = await handleSaveSettings({ showVideo, videoSrc, mainText, slides: localSlides });
+    if (success) {
+      setSlides(localSlides);
+      alert('Slides data saved!');
+    }
+  };
+
+  const handleMainTextSave = async () => {
+    const success = await handleSaveSettings({ showVideo, videoSrc, slides, mainText: localMainText });
+    if (success) {
+      setMainText(localMainText);
+      alert('Main text saved!');
     }
   };
 
@@ -50,24 +75,6 @@ const AdminPage: React.FC = () => {
     setLocalSlides(updatedSlides);
   };
 
-  const handleSlidesSave = async () => {
-    const newSettings = { showVideo, videoSrc, slides: localSlides };
-    const apiUrl = `${import.meta.env.VITE_API_BASE_URL}/api/settings`;
-    try {
-      const response = await fetch(apiUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(newSettings),
-      });
-      if (!response.ok) throw new Error('Failed to save settings.');
-      setSlides(localSlides);
-      alert('Slides data saved!');
-    } catch (error) {
-      console.error(error);
-      alert('Error saving slides data.');
-    }
-  };
-
   return (
     <div className="p-8 text-white">
       <h1 className="text-3xl font-bold mb-6">Admin Panel</h1>
@@ -86,19 +93,9 @@ const AdminPage: React.FC = () => {
             <p>Current Mode: {showVideo ? 'Video Background' : 'Slideshow'}</p>
             <button
               onClick={async () => {
-                const newSettings = { videoSrc, slides, showVideo: !showVideo };
-                const apiUrl = `${import.meta.env.VITE_API_BASE_URL}/api/settings`;
-                try {
-                  const response = await fetch(apiUrl, {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(newSettings),
-                  });
-                  if (!response.ok) throw new Error('Failed to save settings.');
+                const success = await handleSaveSettings({ videoSrc, slides, mainText, showVideo: !showVideo });
+                if (success) {
                   toggleShowVideo();
-                } catch (error) {
-                  console.error(error);
-                  alert('Error saving display mode.');
                 }
               }}
               className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-md transition-colors"
@@ -124,6 +121,25 @@ const AdminPage: React.FC = () => {
               className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-md transition-colors self-start"
             >
               Save Video URL
+            </button>
+          </div>
+        </div>
+
+        <div className="bg-gray-800 p-6 rounded-lg opacity-100 disabled:opacity-50">
+          <h2 className="text-xl font-semibold mb-4">Manage Main Content Text</h2>
+          <div className="flex flex-col space-y-2">
+            <label htmlFor="main-text">Text for Sidebar and Content</label>
+            <textarea
+              id="main-text"
+              value={localMainText}
+              onChange={(e) => setLocalMainText(e.target.value)}
+              className="p-2 rounded bg-gray-700 border border-gray-600 h-32"
+            />
+            <button
+              onClick={handleMainTextSave}
+              className="px-4 py-2 bg-green-600 hover:bg-green-700 text-white rounded-md transition-colors self-start"
+            >
+              Save Main Text
             </button>
           </div>
         </div>

--- a/src/components/ConceptHomePage.tsx
+++ b/src/components/ConceptHomePage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useUIState } from '../contexts/UIContext';
 import RadioPlayer from './RadioPlayer';
 import MobileTicker from './mobile/MobileTicker';
 
@@ -27,6 +28,7 @@ const mobileContent = {
 
 const ConceptHomePage: React.FC = () => {
   const [currentImageIndex, setCurrentImageIndex] = useState(0);
+  const { mainText } = useUIState();
 
   useEffect(() => {
     const interval = setInterval(() => {
@@ -60,15 +62,9 @@ const ConceptHomePage: React.FC = () => {
       {/* Content Section - DESKTOP */}
       <div className="hidden lg:block lg:w-[65%] p-4">
         <div className="h-[calc(100vh-12rem)] text-white">
-          <h3 className="text-lg font-semibold mb-4">{desktopContent.title}</h3>
           <div className="space-y-3">
             <div className="text-2xl lg:text-4xl opacity-80">
-              <p>{desktopContent.welcome}</p>
-              <p className="text-xl lg:text-2xl">{desktopContent.welcomeSubtitle}</p>
-            </div>
-            <div className="text-2xl lg:text-4xl opacity-80">
-              <p>{desktopContent.nowPlaying}</p>
-              <p className="text-xl lg:text-2xl">{desktopContent.nowPlayingSubtitle}</p>
+              <p>{mainText}</p>
             </div>
           </div>
         </div>

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -7,7 +7,7 @@ import { useUIState } from '../contexts/UIContext';
 
 const HomePage: React.FC = () => {
   const [currentSlide, setCurrentSlide] = useState<HeroSlide | null>(null);
-  const { showVideo, videoSrc, slides, isLoading, error } = useUIState();
+  const { showVideo, videoSrc, slides, mainText, isLoading, error } = useUIState();
 
   const handleSlideChange = (slide: HeroSlide) => {
     setCurrentSlide(slide);
@@ -46,11 +46,9 @@ const HomePage: React.FC = () => {
           <div className="col-start-1 row-start-1 p-4 lg:w-[25%]">
             <div className="h-full p-6 bg-[#1b1b1e] rounded-3xl shadow-2xl lg:h-[calc(100vh-12rem)]">
               <div className="text-white">
-                <h3 className="mb-4 text-3xl font-semibold">Radio Info</h3>
                 <div className="space-y-3">
                   <div className="text-1xl opacity-80">
-                    <p>Now Playing</p>
-                    <p className="font-medium">Live Stream</p>
+                    <p>{mainText}</p>
                   </div>
                 </div>
               </div>

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -5,6 +5,7 @@ interface UIState {
   showVideo: boolean;
   videoSrc: string;
   slides: HeroSlide[];
+  mainText: string;
   isLoading: boolean;
   error: string | null;
 }
@@ -13,6 +14,7 @@ interface UIActions {
   toggleShowVideo: () => void;
   setVideoSrc: (url: string) => void;
   setSlides: (slides: HeroSlide[]) => void;
+  setMainText: (text: string) => void;
 }
 
 const UIStateContext = createContext<UIState | undefined>(undefined);
@@ -26,6 +28,7 @@ export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
   const [showVideo, setShowVideo] = useState(false);
   const [videoSrc, setVideoSrc] = useState('');
   const [slides, setSlides] = useState<HeroSlide[]>([]);
+  const [mainText, setMainText] = useState('');
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -41,6 +44,7 @@ export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
         setShowVideo(data.showVideo);
         setVideoSrc(data.videoSrc);
         setSlides(data.slides);
+        setMainText(data.mainText || '');
         setError(null);
       } catch (error) {
         console.error('Failed to fetch settings:', error);
@@ -54,11 +58,12 @@ export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
 
   const toggleShowVideo = () => setShowVideo(prev => !prev);
 
-  const state: UIState = { showVideo, videoSrc, slides, isLoading, error };
+  const state: UIState = { showVideo, videoSrc, slides, mainText, isLoading, error };
   const actions: UIActions = {
     toggleShowVideo,
     setVideoSrc,
     setSlides,
+    setMainText,
   };
 
   return (


### PR DESCRIPTION
This commit introduces a new feature that allows administrators to manage a block of text that is displayed on the homepage sidebar and in the content area of other relevant pages.

The changes include:
- A new `mainText` field in the backend database (`db.json`).
- Updated frontend state management in `UIContext.tsx` to handle the new text field.
- A new section in the `AdminPage.tsx` component with a textarea and save button to edit the `mainText`.
- The `HomePage.tsx` and `ConceptHomePage.tsx` components have been updated to display the dynamic `mainText` from the UI context, replacing the previously hardcoded text.

This commit also includes the necessary fixes from the previous debugging session, which resolved issues with loading environment variables in Vite by using `.env.development` and `.env.production` files.