### PR TITLE
Feat: Add main text management and update dynamic ticker

### DIFF
--- a/src/components/DynamicTicker.tsx
+++ b/src/components/DynamicTicker.tsx
@@ -3,22 +3,29 @@ import { HeroSlide } from './HeroSection';
 
 interface DynamicTickerProps {
   slide: HeroSlide | null;
+  mainText: string;
 }
 
-const DynamicTicker: React.FC<DynamicTickerProps> = ({ slide }) => {
-  if (!slide) {
-    return null;
-  }
-
-  const typeText = slide.type === 'show' ? 'Live Show' :
-                   slide.type === 'news' ? 'News' : 'Event';
+const DynamicTicker: React.FC<DynamicTickerProps> = ({ slide, mainText }) => {
+  const typeText = slide
+    ? slide.type === 'show'
+      ? 'Live Show'
+      : slide.type === 'news'
+      ? 'News'
+      : 'Event'
+    : '';
 
   return (
     <div className="text-white overflow-hidden w-full">
       <div className="animate-marquee whitespace-nowrap">
-        <span className="mx-4 font-bold">{slide.title}</span>
-        <span className="mx-4">{slide.subtitle}</span>
-        <span className="mx-4 text-liquid-lava font-medium">{typeText}</span>
+        <span className="mx-4">{mainText}</span>
+        {slide && (
+          <>
+            <span className="mx-4 font-bold">{slide.title}</span>
+            <span className="mx-4">{slide.subtitle}</span>
+            <span className="mx-4 text-liquid-lava font-medium">{typeText}</span>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/HomePage.tsx
+++ b/src/components/HomePage.tsx
@@ -33,7 +33,7 @@ const HomePage: React.FC = () => {
         <div className="w-full h-[50%] rounded-lg overflow-hidden rounded-3xl shadow-2xl bg-[#151419]">
           {renderContent()}
         </div>
-        <DynamicTicker slide={currentSlide} />
+        <DynamicTicker slide={currentSlide} mainText={mainText} />
         <div className="flex-grow">
           <NewRadioPlayer />
         </div>


### PR DESCRIPTION
This commit introduces a new feature that allows administrators to manage a block of text that is displayed on the homepage sidebar, the content area of the concept page, and in the dynamic ticker.

The changes include:
- A new `mainText` field in the backend database (`db.json`).
- Updated frontend state management in `UIContext.tsx` to handle the new text field.
- A new section in the `AdminPage.tsx` component with a textarea and save button to edit the `mainText`.
- The `HomePage.tsx`, `ConceptHomePage.tsx`, and `DynamicTicker.tsx` components have been updated to display the dynamic `mainText` from the UI context.

This commit also includes the necessary fixes from the previous debugging session, which resolved issues with loading environment variables in Vite by using `.env.development` and `.env.production` files.