### PR TITLE
This commit fixes an issue where the playlist slider cards were overl…

### DIFF
--- a/src/components/PlaylistsPage.tsx
+++ b/src/components/PlaylistsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import useEmblaCarousel from 'embla-carousel-react';
-import { Play, Clock, Music } from 'lucide-react';
+import { Play, Clock } from 'lucide-react';
 import type { Playlist } from '../types';
 import { cn } from '../lib/utils';
 
@@ -105,12 +105,7 @@ const PlaylistsPage: React.FC = () => {
               )}
             >
               <div className="bg-container-dark backdrop-blur-md rounded-2xl overflow-hidden h-full">
-                {/* Playlist Header */}
-
                 <div className="relative h-full">
-
-                <div className="relative">
-
                   <img
                     src={playlist.image}
                     alt={playlist.name}

--- a/src/components/PlaylistsPage.tsx
+++ b/src/components/PlaylistsPage.tsx
@@ -93,20 +93,20 @@ const PlaylistsPage: React.FC = () => {
   };
 
   return (
-    <div className="w-full h-[calc(100vh-128px)] flex flex-col items-center justify-center">
-      <div className="overflow-hidden w-full" ref={emblaRef}>
-        <div className="flex">
+    <div className="w-full h-[calc(100vh-12rem)] lg:h-[calc(100vh-8rem)] flex flex-col items-center justify-center">
+      <div className="overflow-hidden w-full h-full" ref={emblaRef}>
+        <div className="flex h-full">
           {playlists.map((playlist, index) => (
             <div
               key={playlist.id}
               className={cn(
-                'flex-[0_0_80%] md:flex-[0_0_40%] min-w-0 pl-4 transition-transform duration-300 ease-out',
+                'flex-[0_0_80%] md:flex-[0_0_40%] min-w-0 pl-4 transition-transform duration-300 ease-out h-full',
                 index === selectedIndex ? 'scale-100 opacity-100' : 'scale-90 opacity-50'
               )}
             >
-              <div className="bg-container-dark backdrop-blur-md rounded-2xl overflow-hidden">
+              <div className="bg-container-dark backdrop-blur-md rounded-2xl overflow-hidden h-full">
                 {/* Playlist Header */}
-                <div className="relative h-60">
+                <div className="relative h-full">
                   <img
                     src={playlist.image}
                     alt={playlist.name}


### PR DESCRIPTION
…apping the bottom navigation bar on smaller screens.

The height of the slider container and the cards themselves are now responsive, ensuring they correctly fill the available viewport space without overflowing.

- The main container's height is now calculated based on the viewport height, similar to the homepage layout (`h-[calc(100vh-12rem)]` for mobile and `lg:h-[calc(100vh-8rem)]` for desktop).
- The fixed height has been removed from the playlist cards, and they now use `h-full` to dynamically resize and fit within their container.