### PR TITLE
feat: Redesign playlist page and add single playlist view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
+import { Routes, Route, useLocation } from 'react-router-dom';
 import Layout from './components/Layout';
 import HomePage from './components/HomePage';
 import ConceptHomePage from './components/ConceptHomePage';
@@ -7,43 +8,27 @@ import PlaylistsPage from './components/PlaylistsPage';
 import PodcastsPage from './components/PodcastsPage';
 import ResidentsPage from './components/ResidentsPage';
 import AdminPage from './components/AdminPage';
+import SinglePlaylistPage from './pages/SinglePlaylistPage';
 import { UIProvider } from './contexts/UIContext';
 
 function App() {
-  const [currentPage, setCurrentPage] = useState('home');
-
-  useEffect(() => {
-    const path = window.location.pathname;
-    if (path === '/admin') {
-      setCurrentPage('admin');
-    }
-  }, []);
-
-  const renderPage = () => {
-    switch (currentPage) {
-      case 'home':
-        return <HomePage />;
-      case 'concept':
-        return <ConceptHomePage />;
-      case 'video':
-        return <Videobg />;
-      case 'playlists':
-        return <PlaylistsPage />;
-      case 'podcasts':
-        return <PodcastsPage />;
-      case 'residents':
-        return <ResidentsPage />;
-      case 'admin':
-        return <AdminPage />;
-      default:
-        return <ConceptHomePage />;
-    }
-  };
+  const location = useLocation();
+  const currentPage = location.pathname.substring(1) || 'home';
 
   return (
     <UIProvider>
-      <Layout currentPage={currentPage} onPageChange={setCurrentPage}>
-        {renderPage()}
+      <Layout currentPage={currentPage} onPageChange={() => {}}>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/concept" element={<ConceptHomePage />} />
+          <Route path="/video" element={<Videobg />} />
+          <Route path="/playlists" element={<PlaylistsPage />} />
+          <Route path="/podcasts" element={<PodcastsPage />} />
+          <Route path="/residents" element={<ResidentsPage />} />
+          <Route path="/admin" element={<AdminPage />} />
+          <Route path="/playlist/:id" element={<SinglePlaylistPage />} />
+          <Route path="*" element={<ConceptHomePage />} />
+        </Routes>
       </Layout>
     </UIProvider>
   );

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { Home, Music, Mic, Users, Grid3X3, Video } from 'lucide-react';
 
 interface LayoutProps {
@@ -7,18 +8,18 @@ interface LayoutProps {
   onPageChange: (page: string) => void;
 }
 
-const Layout: React.FC<LayoutProps> = ({ children, currentPage, onPageChange }) => {
+const Layout: React.FC<LayoutProps> = ({ children, currentPage }) => {
   const navItems = [
-    { id: 'home', label: 'Home', icon: Home },
-    { id: 'concept', label: 'Concept', icon: Music },
-    { id: 'video', label: 'Video', icon: Video },
-    { id: 'playlists', label: 'Playlist', icon: Music },
-    { id: 'podcasts', label: 'Podcast', icon: Mic },
-    { id: 'residents', label: 'Residents', icon: Users },
+    { id: 'home', path: '/', label: 'Home', icon: Home },
+    { id: 'concept', path: '/concept', label: 'Concept', icon: Music },
+    { id: 'video', path: '/video', label: 'Video', icon: Video },
+    { id: 'playlists', path: '/playlists', label: 'Playlist', icon: Music },
+    { id: 'podcasts', path: '/podcasts', label: 'Podcast', icon: Mic },
+    { id: 'residents', path: '/residents', label: 'Residents', icon: Users },
   ];
 
   const getBackgroundClass = () => {
-    if (currentPage === 'playlists' || currentPage === 'podcasts') {
+    if (currentPage === 'playlists' || currentPage === 'podcasts' || currentPage.startsWith('playlist/')) {
       return 'bg-background-dark';
     }
     return 'bg-global-bg';
@@ -59,9 +60,9 @@ const Layout: React.FC<LayoutProps> = ({ children, currentPage, onPageChange }) 
               const Icon = item.icon;
               const isActive = currentPage === item.id;
               return (
-                <button
+                <Link
                   key={item.id}
-                  onClick={() => onPageChange(item.id)}
+                  to={item.path}
                   className={`flex flex-col items-center py-2 px-3 transition-all ${
                     isActive 
                       ? 'text-white bg-white/20 rounded-full'
@@ -70,7 +71,7 @@ const Layout: React.FC<LayoutProps> = ({ children, currentPage, onPageChange }) 
                 >
                   <Icon size={20} />
                   <span className="text-xs mt-1">{item.label}</span>
-                </button>
+                </Link>
               );
             })}
           </div>

--- a/src/components/PlaylistsPage.tsx
+++ b/src/components/PlaylistsPage.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import useEmblaCarousel from 'embla-carousel-react';
 import Autoplay from 'embla-carousel-autoplay';
-import { Play, ChevronLeft, ChevronRight } from 'lucide-react';
+import { Link } from 'react-router-dom';
+import { Play, ChevronLeft, ChevronRight, ArrowUpRight } from 'lucide-react';
 import type { Playlist } from '../types';
 import { cn } from '../lib/utils';
 
@@ -149,6 +150,13 @@ const PlaylistsPage: React.FC = () => {
                       className="w-full h-full object-cover"
                     />
                     <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent" />
+
+                    {index === selectedIndex && (
+                      <button className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white text-black p-4 rounded-full shadow-lg transition-transform hover:scale-110 z-10">
+                        <Play size={24} className="fill-black" />
+                      </button>
+                    )}
+
                     <div className="absolute bottom-4 left-4 right-4">
                       <h3 className="text-text-main font-bold text-xl mb-1">{playlist.name}</h3>
                       <p className="text-gray-400 text-sm mb-3">{playlist.description}</p>
@@ -158,9 +166,9 @@ const PlaylistsPage: React.FC = () => {
                           <span>•</span>
                           <span>{getTotalDuration(playlist.tracks)}</span>
                         </div>
-                        <button className="bg-liquid-lava hover:bg-liquid-lava/80 text-text-main p-3 rounded-full transition-colors">
-                          <Play size={20} />
-                        </button>
+                        <Link to={`/playlist/${playlist.id}`} className="bg-transparent text-white p-2 rounded-full transition-colors hover:bg-white/10">
+                          <ArrowUpRight size={20} />
+                        </Link>
                       </div>
                     </div>
                   </div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter as Router } from 'react-router-dom';
 import App from './App.tsx';
 import { PlayerProvider } from './contexts/PlayerContext.tsx';
 import './index.css';
@@ -7,8 +8,10 @@ import './spinner.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <PlayerProvider>
-      <App />
-    </PlayerProvider>
+    <Router>
+      <PlayerProvider>
+        <App />
+      </PlayerProvider>
+    </Router>
   </StrictMode>
 );

--- a/src/pages/SinglePlaylistPage.tsx
+++ b/src/pages/SinglePlaylistPage.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { useParams } from 'react-router-dom';
+import type { Playlist, Track } from '../types';
+import { Clock, Play } from 'lucide-react';
+
+// Mock data - in a real app, this would come from a context or API call
+const playlists: Playlist[] = [
+  {
+    id: '1',
+    name: 'Deep House',
+    description: 'The best deep house tracks for your soul',
+    image: 'https://res.cloudinary.com/thinkdigital/image/upload/v1754298552/png_1_odwcbw.png',
+    tracks: [
+      { id: '1', title: 'Midnight City', artist: 'M83', duration: '4:03' },
+      { id: '2', title: 'Strobe', artist: 'Deadmau5', duration: '10:32' },
+      { id: '3', title: 'Teardrop', artist: 'Massive Attack', duration: '5:29' }
+    ]
+  },
+  {
+    id: '2',
+    name: 'Morning Energy',
+    description: 'Uplifting beats to start your day',
+    image: 'https://res.cloudinary.com/thinkdigital/image/upload/v1754298552/png_1_odwcbw.png',
+    tracks: [
+      { id: '4', title: 'One More Time', artist: 'Daft Punk', duration: '5:20' },
+      { id: '5', title: 'Levels', artist: 'Avicii', duration: '6:02' },
+      { id: '6', title: 'Titanium', artist: 'David Guetta ft. Sia', duration: '4:05' }
+    ]
+  },
+  {
+    id: '3',
+    name: 'Chill Vibes',
+    description: 'Relaxing sounds for peaceful moments',
+    image: 'https://res.cloudinary.com/thinkdigital/image/upload/v1754298552/png_1_odwcbw.png',
+    tracks: [
+      { id: '7', title: 'Weightless', artist: 'Marconi Union', duration: '8:08' },
+      { id: '8', title: 'Porcelain', artist: 'Moby', duration: '4:01' },
+      { id: '9', title: 'Kiara', artist: 'Bonobo', duration: '5:27' }
+    ]
+  },
+  {
+      id: '4',
+      name: 'Techno',
+      description: 'The best deep house tracks for your soul',
+      image: 'https://res.cloudinary.com/thinkdigital/image/upload/v1754298552/png_1_odwcbw.png',
+      tracks: [
+        { id: '1', title: 'Midnight City', artist: 'M83', duration: '4:03' },
+        { id: '2', title: 'Strobe', artist: 'Deadmau5', duration: '10:32' },
+        { id: '3', title: 'Teardrop', artist: 'Massive Attack', duration: '5:29' }
+      ]
+    },
+    {
+      id: '5',
+      name: 'Afro House',
+      description: 'Uplifting beats to start your day',
+      image: 'https://res.cloudinary.com/thinkdigital/image/upload/v1754298552/png_1_odwcbw.png',
+      tracks: [
+        { id: '4', title: 'One More Time', artist: 'Daft Punk', duration: '5:20' },
+        { id: '5', title: 'Levels', artist: 'Avicii', duration: '6:02' },
+        { id: '6', title: 'Titanium', artist: 'David Guetta ft. Sia', duration: '4:05' }
+      ]
+    },
+];
+
+
+const SinglePlaylistPage: React.FC = () => {
+  const { id } = useParams<{ id: string }>();
+  const playlist = playlists.find(p => p.id === id);
+
+  if (!playlist) {
+    return <div className="text-white text-center p-8">Playlist not found</div>;
+  }
+
+  const getTotalDuration = (tracks: any[]) => {
+    const totalSeconds = tracks.reduce((acc, track) => {
+      const [minutes, seconds] = track.duration.split(':').map(Number);
+      return acc + minutes * 60 + seconds;
+    }, 0);
+    const hours = Math.floor(totalSeconds / 3600);
+    const minutes = Math.floor((totalSeconds % 3600) / 60);
+    return hours > 0 ? `${hours}h ${minutes}m` : `${minutes}m`;
+  };
+
+  return (
+    <div className="w-full min-h-screen text-white p-4 md:p-8">
+      <div className="flex flex-col md:flex-row gap-8">
+        <div className="w-full md:w-1/3">
+          <img src={playlist.image} alt={playlist.name} className="w-full h-auto object-cover rounded-lg shadow-lg" />
+          <h1 className="text-3xl font-bold mt-4">{playlist.name}</h1>
+          <p className="text-gray-400 mt-2">{playlist.description}</p>
+          <div className="flex items-center space-x-4 text-gray-400 text-sm mt-4">
+            <span>{playlist.tracks.length} tracks</span>
+            <span>•</span>
+            <span>{getTotalDuration(playlist.tracks)}</span>
+          </div>
+          <button className="mt-6 w-full bg-liquid-lava text-white py-3 rounded-full flex items-center justify-center gap-2 font-bold transition-transform hover:scale-105">
+            <Play size={20} className="fill-white" />
+            Play All
+          </button>
+        </div>
+        <div className="w-full md:w-2/3">
+          <div className="flex flex-col space-y-2">
+            <div className="grid grid-cols-[2rem_1fr_1fr_auto] gap-4 items-center text-gray-400 uppercase text-sm border-b border-gray-700 pb-2">
+              <span>#</span>
+              <span>Title</span>
+              <span>Artist</span>
+              <Clock size={16} />
+            </div>
+            {playlist.tracks.map((track, index) => (
+              <div key={track.id} className="grid grid-cols-[2rem_1fr_1fr_auto] gap-4 items-center p-2 rounded-md hover:bg-white/10 transition-colors">
+                <span className="text-gray-400">{index + 1}</span>
+                <span className="font-medium">{track.title}</span>
+                <span className="text-gray-400">{track.artist}</span>
+                <span className="text-gray-400">{track.duration}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SinglePlaylistPage;


### PR DESCRIPTION
This commit introduces a major redesign of the playlist functionality:

- Refactors the application to use `react-router-dom` for navigation, replacing the previous state-based routing.
- Creates a new `SinglePlaylistPage` to display the full tracklist for a selected playlist, accessible via the `/playlist/:id` route.
- Restyles the play button on the playlist cards to be centered with a white, rounded background and a black icon, appearing only on the active slide.
- Adds a "View All" button to each playlist card, linking to the new single playlist page.