### PR TITLE
feat: Redesign SinglePlaylistPage layout and apply style updates

### DIFF
--- a/src/components/music/PlaylistDropdown.tsx
+++ b/src/components/music/PlaylistDropdown.tsx
@@ -11,23 +11,23 @@ const PlaylistDropdown: React.FC<PlaylistDropdownProps> = ({ playlist, onTrackSe
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <div className="relative z-10 w-full max-w-4xl mx-auto">
+    <div className="relative z-20 w-full max-w-4xl mx-auto">
       <div className={`
         bg-gluon-grey/20 backdrop-blur-md border-none text-white rounded-2xl
         transition-all duration-500 ease-in-out overflow-hidden
-        ${isOpen ? 'h-[70vh]' : 'h-24'}
+        ${isOpen ? 'h-[70vh]' : 'h-16'}
       `}>
         <div className="p-6 flex flex-col h-full">
           {/* Header */}
           <div
-            className="flex items-center justify-between cursor-pointer"
+            className={`flex items-center cursor-pointer ${isOpen ? 'justify-between' : 'justify-center'}`}
             onClick={() => setIsOpen(!isOpen)}
           >
             <div className="flex items-center space-x-4">
-              <img src={playlist.image} alt={playlist.name} className="w-12 h-12 rounded-lg object-cover" />
+              <img src={playlist.image} alt={playlist.name} className={`w-12 h-12 rounded-lg object-cover transition-opacity duration-300 ${isOpen ? 'opacity-100' : 'opacity-0'}`} />
               <div>
                 <h2 className="text-xl font-bold">{playlist.name}</h2>
-                <p className="text-gray-300 text-sm">{playlist.description}</p>
+                <p className={`text-gray-300 text-sm transition-opacity duration-300 ${isOpen ? 'opacity-100' : 'opacity-0'}`}>{playlist.description}</p>
               </div>
             </div>
             <ChevronDown

--- a/src/components/music/PlaylistPlayer.tsx
+++ b/src/components/music/PlaylistPlayer.tsx
@@ -155,11 +155,11 @@ const PlaylistPlayer: React.FC<PlaylistPlayerProps> = ({
       />
 
       {/* Unified Layout */}
-      <div className="bg-gluon-grey/20 backdrop-blur-md border-none text-white rounded-2xl p-4 w-full">
-        <div className="flex items-center justify-between gap-4">
+      <div className="bg-gluon-grey/20 backdrop-blur-md border-none text-white rounded-2xl p-4 w-full h-[12rem]">
+        <div className="flex items-center justify-between gap-4 h-full">
 
           {/* Left: Track Info & Volume */}
-          <div className="flex items-center gap-3 w-1/3">
+          <div className="flex items-center gap-3 w-1/3 h-full">
             <img
               src={playlistImage}
               alt={playlistName}

--- a/src/pages/SinglePlaylistPage.tsx
+++ b/src/pages/SinglePlaylistPage.tsx
@@ -90,10 +90,12 @@ const SinglePlaylistPage: React.FC = () => {
       </div>
 
       {/* Top Section: Playlist Dropdown */}
-      <PlaylistDropdown playlist={playlist} onTrackSelect={handleTrackSelect} />
+      <div className="w-full max-w-[35rem] mb-4">
+        <PlaylistDropdown playlist={playlist} onTrackSelect={handleTrackSelect} />
+      </div>
 
       {/* Bottom Section: Playlist Player */}
-      <div className="w-full max-w-4xl z-10">
+      <div className="w-full max-w-[35rem] z-10">
         <PlaylistPlayer 
           tracks={playlist.tracks}
           playlistName={playlist.name}


### PR DESCRIPTION
This commit completely redesigns the Single Playlist Page and applies specific styling adjustments as requested by the user.

Key changes include:
- A new `PlaylistDropdown` component has been created to house the playlist details and an expandable tracklist.
- The `SinglePlaylistPage` layout has been refactored to a top-and-bottom flex structure, placing the new dropdown at the top and the player at the bottom.
- The `PlaylistPlayer` component has been updated with a unified, responsive layout that is centered at the bottom of the screen.

Style updates based on user feedback:
- Both the dropdown and player containers are set to a max-width of 35rem.
- The player component now has a fixed height of 12rem.
- The dropdown component has a collapsed height of 4rem, and its header text is centered when collapsed.
- The dropdown's z-index has been increased to ensure it correctly layers over the player when expanded.