### PR TITLE
This commit adjusts the mobile positioning of the player component on…

### DIFF
--- a/src/pages/SinglePlaylistPage.tsx
+++ b/src/pages/SinglePlaylistPage.tsx
@@ -113,7 +113,7 @@ const SinglePlaylistPage: React.FC = () => {
         </div>
 
         {/* Player Container */}
-        <div className="w-full lg:w-[30%] lg:h-full flex items-end lg:items-center">
+        <div className="fixed bottom-[30px] left-4 right-4 z-20 lg:relative lg:bottom-auto lg:left-auto lg:right-auto lg:w-[30%] lg:h-full flex lg:items-center">
           <div className="w-full flex flex-col gap-2">
             {/* Share Bar for Mobile - positioned above the player */}
             <div className="lg:hidden mb-1.5">

--- a/src/pages/SinglePodcastPage.tsx
+++ b/src/pages/SinglePodcastPage.tsx
@@ -78,7 +78,7 @@ const SinglePodcastPage: React.FC = () => {
         </div>
 
         {/* Player Container */}
-        <div className="w-full lg:w-[30%] lg:h-full flex items-end lg:items-center">
+        <div className="fixed bottom-[30px] left-4 right-4 z-20 lg:relative lg:bottom-auto lg:left-auto lg:right-auto lg:w-[30%] lg:h-full flex lg:items-center">
           <div className="w-full flex flex-col gap-2">
             {/* Share Bar for Mobile - positioned above the player */}
             <div className="lg:hidden mb-1.5">

--- a/src/pages/SingleResidentPage.tsx
+++ b/src/pages/SingleResidentPage.tsx
@@ -84,7 +84,7 @@ const SingleResidentPage: React.FC = () => {
         </div>
 
         {/* Player Container */}
-        <div className="w-full lg:w-[30%] lg:h-full flex items-end lg:items-center">
+        <div className="fixed bottom-[30px] left-4 right-4 z-20 lg:relative lg:bottom-auto lg:left-auto lg:right-auto lg:w-[30%] lg:h-full flex lg:items-center">
           <div className="w-full flex flex-col gap-2">
             {/* Share Bar for Mobile - positioned above the player */}
             <div className="lg:hidden mb-1.5">


### PR DESCRIPTION
… the `SinglePodcastPage`, `SinglePlaylistPage`, and `SingleResidentPage`.

The player container on these pages is now positioned 30px from the bottom of the viewport on mobile screens. This is achieved by applying fixed positioning and a `bottom-[30px]` class. The desktop layout remains unaffected.

This change addresses the user's final request for a consistent margin on all detail page players on mobile devices.