### PR TITLE
This commit introduces two main changes:

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { Home, Music, Mic, Users, Grid3X3, Video } from 'lucide-react';
+import { useUIState, useUIActions } from '../contexts/UIContext';
+import ResidentsModal from './modals/ResidentsModal';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -9,6 +11,9 @@ interface LayoutProps {
 }
 
 const Layout: React.FC<LayoutProps> = ({ children, currentPage }) => {
+  const { isResidentsModalOpen } = useUIState();
+  const { toggleResidentsModal } = useUIActions();
+
   const navItems = [
     { id: 'home', path: '/', label: 'Home', icon: Home },
     { id: 'concept', path: '/concept', label: 'Concept', icon: Music },
@@ -28,7 +33,7 @@ const Layout: React.FC<LayoutProps> = ({ children, currentPage }) => {
   return (
     <div className={`min-h-screen flex flex-col ${getBackgroundClass()}`}>
       {/* Header */}
-      <header className="sticky top-0 z-50">
+      <header className="sticky top-0 z-40">
         <div className=" mx-auto px-4 py-4">
           <div className="flex items-center justify-between">
             <div className="flex items-center space-x-3">
@@ -55,10 +60,28 @@ const Layout: React.FC<LayoutProps> = ({ children, currentPage }) => {
       {/* Bottom Navigation */}
       <nav className="fixed bottom-0 left-0 right-0 z-50">
         <div className="max-w-md mx-auto lg:max-w-4xl px-4">
-          <div className="flex justify-around py-2">
+          <div className="bg-black/50 backdrop-blur-md rounded-full flex justify-around py-2">
             {navItems.map((item) => {
               const Icon = item.icon;
-              const isActive = currentPage === item.id;
+              const isActive = currentPage === item.id || (item.id === 'residents' && isResidentsModalOpen);
+
+              if (item.id === 'residents') {
+                return (
+                  <button
+                    key={item.id}
+                    onClick={toggleResidentsModal}
+                    className={`flex flex-col items-center py-2 px-3 transition-all ${
+                      isActive
+                        ? 'text-white bg-white/20 rounded-full'
+                        : 'text-gray-400 hover:text-white'
+                    }`}
+                  >
+                    <Icon size={20} />
+                    <span className="text-xs mt-1">{item.label}</span>
+                  </button>
+                );
+              }
+
               return (
                 <Link
                   key={item.id}
@@ -66,7 +89,7 @@ const Layout: React.FC<LayoutProps> = ({ children, currentPage }) => {
                   className={`flex flex-col items-center py-2 px-3 transition-all ${
                     isActive 
                       ? 'text-white bg-white/20 rounded-full'
-                      : 'text-gray-400 hover:text-white rounded-lg'
+                      : 'text-gray-400 hover:text-white'
                   }`}
                 >
                   <Icon size={20} />
@@ -77,6 +100,8 @@ const Layout: React.FC<LayoutProps> = ({ children, currentPage }) => {
           </div>
         </div>
       </nav>
+
+      <ResidentsModal isOpen={isResidentsModalOpen} onClose={toggleResidentsModal} />
     </div>
   );
 };

--- a/src/components/modals/ResidentsModal.tsx
+++ b/src/components/modals/ResidentsModal.tsx
@@ -1,0 +1,157 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { X, Users, Instagram, Music2, ExternalLink, Play } from 'lucide-react';
+import type { Resident } from '../../types';
+
+interface ResidentsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+// Mock data - This should ideally be fetched from a central place
+const residents: Resident[] = [
+    {
+      id: '1',
+      name: 'DJ Marco',
+      bio: 'Marco brings over 10 years of experience in deep house and techno. His morning shows are the perfect way to start your day with positive energy.',
+      image: 'https://res.cloudinary.com/thinkdigital/image/upload/v1754294998/Schermata_2020-04-13_alle_20.25.01_brwvys.png',
+      shows: ['Morning Vibes', 'Weekend Deep Sessions'],
+      socialLinks: {
+        instagram: 'https://instagram.com/djmarco',
+        soundcloud: 'https://soundcloud.com/djmarco',
+        mixcloud: 'https://mixcloud.com/djmarco'
+      }
+    },
+    {
+      id: '2',
+      name: 'Sara Mix',
+      bio: 'Sara is our electronic music specialist with a passion for discovering new artists. She curates the perfect lunch break soundtrack.',
+      image: 'https://res.cloudinary.com/thinkdigital/image/upload/v1754294960/7488-7d7f-4931-aa4c-01e4f93d3279_jjkinc.png',
+      shows: ['Lunch Break Beats', 'New Music Friday'],
+      socialLinks: {
+        instagram: 'https://instagram.com/saramix',
+        soundcloud: 'https://soundcloud.com/saramix'
+      }
+    },
+    {
+      id: '3',
+      name: 'Alex Deep',
+      bio: 'Alex specializes in progressive house and ambient sounds. His evening sessions are designed to help you unwind after a long day.',
+      image: 'https://res.cloudinary.com/thinkdigital/image/upload/v1754294921/6688-af9a-4e1c-9373-edf1c47164e9_ydrkce.jpg',
+      shows: ['Evening Sessions', 'Midnight Ambient'],
+      socialLinks: {
+        instagram: 'https://instagram.com/alexdeep',
+        mixcloud: 'https://mixcloud.com/alexdeep'
+      }
+    },
+    {
+      id: '4',
+      name: 'Luna Beats',
+      bio: 'Luna brings the underground scene to Radio Amblè with her selection of cutting-edge electronic music and exclusive mixes.',
+      image: 'https://res.cloudinary.com/thinkdigital/image/upload/v1754314593/b663-8e1c-4bf8-975e-ec025ce7c823_1_gbsrm2.png',
+      shows: ['Underground Sounds', 'Late Night Sessions'],
+      socialLinks: {
+        instagram: 'https://instagram.com/lunabeats',
+        soundcloud: 'https://soundcloud.com/lunabeats',
+        mixcloud: 'https://mixcloud.com/lunabeats'
+      }
+    }
+];
+
+const getSocialIcon = (platform: string) => {
+    switch (platform) {
+      case 'instagram': return <Instagram size={18} />;
+      case 'soundcloud': case 'mixcloud': return <Music2 size={18} />;
+      default: return <ExternalLink size={18} />;
+    }
+};
+
+const SocialLinks: React.FC<{ links: { [key: string]: string } }> = ({ links }) => (
+    <div className="flex items-center flex-wrap gap-4">
+      {Object.entries(links).map(([platform, url]) => (
+        <a key={platform} href={url} target="_blank" rel="noopener noreferrer" className="flex items-center space-x-2 text-gray-400 hover:text-liquid-lava transition-colors">
+          {getSocialIcon(platform)}
+          <span className="text-sm capitalize">{platform}</span>
+        </a>
+      ))}
+    </div>
+);
+
+const ResidentsModal: React.FC<ResidentsModalProps> = ({ isOpen, onClose }) => {
+  const navigate = useNavigate();
+  const featuredResident = residents[0];
+  const otherResidents = residents.slice(1);
+
+  const handleResidentClick = (id: string) => {
+    navigate(`/resident/${id}`);
+    onClose();
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/80 backdrop-blur-lg z-50 flex items-end justify-center">
+      <div className="bg-background-dark w-full h-full max-h-[90vh] rounded-t-3xl transform transition-transform duration-500 ease-in-out" style={{ transform: isOpen ? 'translateY(0)' : 'translateY(100%)' }}>
+        <div className="h-full overflow-y-auto p-4 lg:p-8">
+          <div className="flex items-center justify-between mb-6 sticky top-0 bg-background-dark py-4 z-10">
+            <div className="flex items-center space-x-2">
+              <Users className="text-liquid-lava" size={24} />
+              <h2 className="text-text-main font-bold text-2xl">Our Residents</h2>
+            </div>
+            <button onClick={onClose} className="p-2 rounded-full hover:bg-white/10 text-white">
+              <X size={28} />
+            </button>
+          </div>
+
+          {/* Content */}
+          <div className="space-y-6">
+            {/* Featured Resident */}
+            <div className="bg-container-dark backdrop-blur-md rounded-2xl overflow-hidden cursor-pointer" onClick={() => handleResidentClick(featuredResident.id)}>
+              <div className="relative h-56">
+                <img src={featuredResident.image} alt={featuredResident.name} className="w-full h-full object-cover" />
+                <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/50 to-transparent" />
+                <div className="absolute top-4 left-4"><span className="bg-liquid-lava text-text-main text-xs px-3 py-1 rounded-full font-medium">Featured</span></div>
+                <div className="absolute bottom-4 left-4 right-4">
+                  <h3 className="text-text-main font-bold text-xl mb-2">{featuredResident.name}</h3>
+                  <div className="flex flex-wrap gap-2 mb-4">{featuredResident.shows.map((show, idx) => (<span key={idx} className="bg-white/20 text-text-main text-xs px-2 py-1 rounded-full font-medium">{show}</span>))}</div>
+                </div>
+              </div>
+              <div className="p-6">
+                <p className="text-gray-400 text-sm mb-4 line-clamp-3">{featuredResident.bio}</p>
+                <div className="flex items-center justify-between">
+                  <SocialLinks links={featuredResident.socialLinks} />
+                  <button className="bg-white hover:bg-gray-200 text-black p-3 rounded-full transition-colors" onClick={(e) => { e.stopPropagation(); handleResidentClick(featuredResident.id); }}><Play size={20} fill="black" /></button>
+                </div>
+              </div>
+            </div>
+
+            {/* All Residents */}
+            <div>
+              <h3 className="text-text-main font-semibold text-lg mb-4">All Residents</h3>
+              <div className="space-y-4">
+                {otherResidents.map((resident) => (
+                  <div key={resident.id} className="bg-container-dark backdrop-blur-md rounded-xl p-4 hover:bg-slate-grey/30 transition-colors cursor-pointer" onClick={() => handleResidentClick(resident.id)}>
+                    <div className="flex items-start space-x-4">
+                      <img src={resident.image} alt={resident.name} className="w-20 h-20 rounded-full object-cover flex-shrink-0" />
+                      <div className="flex-1 min-w-0">
+                        <h4 className="text-text-main font-medium text-lg mb-2 line-clamp-1">{resident.name}</h4>
+                        <div className="flex flex-wrap gap-1 mb-3">{resident.shows.map((show, idx) => (<span key={idx} className="bg-white/10 text-text-main text-xs px-2 py-1 rounded-full font-medium">{show}</span>))}</div>
+                        <p className="text-gray-400 text-sm mb-3 line-clamp-2">{resident.bio}</p>
+                        <div className="flex items-center justify-between">
+                          <SocialLinks links={resident.socialLinks} />
+                          <button className="bg-white hover:bg-gray-200 text-black p-2 rounded-full transition-colors flex-shrink-0" onClick={(e) => { e.stopPropagation(); handleResidentClick(resident.id); }}><Play size={16} fill="black" /></button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ResidentsModal;

--- a/src/components/shell/DetailLayout.tsx
+++ b/src/components/shell/DetailLayout.tsx
@@ -7,15 +7,6 @@ const DetailLayout: React.FC = () => {
 
   return (
     <div className="h-screen w-screen bg-black">
-      {/* Back button */}
-      <button
-        onClick={() => navigate(-1)}
-        className="absolute top-6 left-6 z-20 text-white bg-black/50 rounded-full p-2 hover:bg-white/20 transition-colors"
-        aria-label="Go back"
-      >
-        <ChevronLeft size={28} />
-      </button>
-
       {/* Page Content */}
       <main className="h-full w-full">
         <Outlet />

--- a/src/contexts/UIContext.tsx
+++ b/src/contexts/UIContext.tsx
@@ -7,12 +7,14 @@ interface UIState {
   slides: HeroSlide[];
   isLoading: boolean;
   error: string | null;
+  isResidentsModalOpen: boolean;
 }
 
 interface UIActions {
   toggleShowVideo: () => void;
   setVideoSrc: (url: string) => void;
   setSlides: (slides: HeroSlide[]) => void;
+  toggleResidentsModal: () => void;
 }
 
 const UIStateContext = createContext<UIState | undefined>(undefined);
@@ -28,6 +30,7 @@ export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
   const [slides, setSlides] = useState<HeroSlide[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [isResidentsModalOpen, setIsResidentsModalOpen] = useState(false);
 
   useEffect(() => {
     const fetchSettings = async () => {
@@ -53,12 +56,14 @@ export const UIProvider: React.FC<UIProviderProps> = ({ children }) => {
   }, []);
 
   const toggleShowVideo = () => setShowVideo(prev => !prev);
+  const toggleResidentsModal = () => setIsResidentsModalOpen(prev => !prev);
 
-  const state: UIState = { showVideo, videoSrc, slides, isLoading, error };
+  const state: UIState = { showVideo, videoSrc, slides, isLoading, error, isResidentsModalOpen };
   const actions: UIActions = {
     toggleShowVideo,
     setVideoSrc,
     setSlides,
+    toggleResidentsModal,
   };
 
   return (


### PR DESCRIPTION
1.  **Residents Modal:** The "Residents" item in the bottom navigation now opens a full-screen modal that slides up from the bottom, displaying the residents list. This is implemented using a new `ResidentsModal` component and managed by state in `UIContext`.
2.  **Arrow Removal:** The back arrow has been removed from the header of the single detail pages (`SinglePodcastPage`, `SinglePlaylistPage`, `SingleResidentPage`) by modifying the `DetailLayout.tsx` component.

These changes improve the user experience by providing a more integrated way to view residents and by cleaning up the UI on detail pages.