### PR TITLE
Removes the absolutely positioned back arrow from the main detail pag…

### DIFF
--- a/src/components/shell/DetailLayout.tsx
+++ b/src/components/shell/DetailLayout.tsx
@@ -7,15 +7,6 @@ const DetailLayout: React.FC = () => {
 
   return (
     <div className="h-screen w-screen bg-black">
-      {/* Back button */}
-      <button
-        onClick={() => navigate(-1)}
-        className="absolute top-6 left-6 z-20 text-white bg-black/50 rounded-full p-2 hover:bg-white/20 transition-colors"
-        aria-label="Go back"
-      >
-        <ChevronLeft size={28} />
-      </button>
-
       {/* Page Content */}
       <main className="h-full w-full">
         <Outlet />


### PR DESCRIPTION
…e layout.

The back arrow was located in `src/components/shell/DetailLayout.tsx` and was positioned outside of the main header content. This change removes the button entirely to provide a cleaner interface on single item pages (playlist, podcast, resident) as requested.