### PR TITLE
feat: Use avatar image for card background

### DIFF
--- a/src/components/ui/EditProfileModal.tsx
+++ b/src/components/ui/EditProfileModal.tsx
@@ -9,7 +9,6 @@ interface EditProfileModalProps {
   selectedAvatar: string;
   onSelectAvatar: (avatarUrl: string) => void;
   onPageBackgroundChange: (file: File) => void;
-  onCardBackgroundChange: (file: File) => void;
   currentPageBackground: string;
   currentCardBackground: string;
 }
@@ -22,12 +21,10 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
   selectedAvatar,
   onSelectAvatar,
   onPageBackgroundChange,
-  onCardBackgroundChange,
   currentPageBackground,
   currentCardBackground
 }) => {
   const [pagePreview, setPagePreview] = useState<string | null>(null);
-  const [cardPreview, setCardPreview] = useState<string | null>(null);
 
   if (!isOpen) {
     return null;
@@ -41,13 +38,6 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
     }
   };
 
-  const handleCardFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files && e.target.files[0]) {
-      const file = e.target.files[0];
-      setCardPreview(URL.createObjectURL(file));
-      onCardBackgroundChange(file);
-    }
-  };
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
@@ -84,17 +74,6 @@ const EditProfileModal: React.FC<EditProfileModalProps> = ({
             />
             <div className="mt-4">
               <img src={pagePreview || currentPageBackground} alt="Page background preview" className="w-full h-32 object-cover rounded-lg" />
-            </div>
-          </div>
-          <div>
-            <h4 className="font-semibold mb-2">Upload card background</h4>
-            <input
-              type="file"
-              onChange={handleCardFileChange}
-              className="w-full text-sm text-white file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-white/10 file:text-white hover:file:bg-white/20"
-            />
-            <div className="mt-4">
-              <img src={cardPreview || currentCardBackground} alt="Card background preview" className="w-full h-32 object-cover rounded-lg" />
             </div>
           </div>
         </div>

--- a/src/pages/UserProfilePage.tsx
+++ b/src/pages/UserProfilePage.tsx
@@ -15,8 +15,6 @@ const UserProfilePage: React.FC = () => {
   const [userAvatarUrl, setUserAvatarUrl] = useState(user?.user_metadata?.avatar_url || 'https://randomuser.me/api/portraits/women/44.jpg');
 
   const [newPageBackgroundFile, setNewPageBackgroundFile] = useState<File | null>(null);
-  const [newCardBackgroundFile, setNewCardBackgroundFile] = useState<File | null>(null);
-
   const userName = user?.user_metadata?.full_name || 'User';
 
   const avatars = [
@@ -46,27 +44,11 @@ const UserProfilePage: React.FC = () => {
       }
     }
 
-    let cardBackgroundUrl = cardBackground;
-    if (newCardBackgroundFile) {
-      const fileExt = newCardBackgroundFile.name.split('.').pop();
-      const filePath = `${user.id}/card_background.${fileExt}`;
-      const { data, error } = await supabase.storage.from('backgrounds').upload(filePath, newCardBackgroundFile, {
-        cacheControl: '3600',
-        upsert: true,
-      });
-      if (error) {
-        console.error('Error uploading card background:', error);
-      } else if (data) {
-        const { data: { publicUrl } } = supabase.storage.from('backgrounds').getPublicUrl(data.path);
-        cardBackgroundUrl = publicUrl;
-      }
-    }
-
     const { error: updateError } = await supabase.auth.updateUser({
       data: {
         avatar_url: userAvatarUrl,
         page_background_url: pageBackgroundUrl,
-        card_background_url: cardBackgroundUrl,
+        card_background_url: userAvatarUrl,
       },
     });
 
@@ -75,9 +57,6 @@ const UserProfilePage: React.FC = () => {
     } else {
       await refreshUser();
     }
-
-    setPageBackground(pageBackgroundUrl);
-    setCardBackground(cardBackgroundUrl);
     setIsModalOpen(false);
   };
 
@@ -142,7 +121,6 @@ const UserProfilePage: React.FC = () => {
         selectedAvatar={userAvatarUrl}
         onSelectAvatar={setUserAvatarUrl}
         onPageBackgroundChange={setNewPageBackgroundFile}
-        onCardBackgroundChange={setNewCardBackgroundFile}
         currentPageBackground={pageBackground}
         currentCardBackground={cardBackground}
       />


### PR DESCRIPTION
This commit simplifies the profile customization page by using the selected avatar image as the card background. This change was made to help debug an issue where the background image was not saving correctly.

- The `UserProfilePage` now uses the `userAvatarUrl` for the `card_background_url` when updating the user's metadata.
- The `EditProfileModal` has been simplified to remove the input field for the card background.